### PR TITLE
Add clear history button

### DIFF
--- a/AIDevGallery/Controls/DownloadProgressList.xaml
+++ b/AIDevGallery/Controls/DownloadProgressList.xaml
@@ -17,10 +17,27 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
         <TextBlock
+            FontWeight="SemiBold"
             Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-            Style="{StaticResource CaptionTextBlockStyle}"
             Text="Downloads" />
+        <Button
+            HorizontalAlignment="Right"
+            AutomationProperties.Name="More options"
+            Content="{ui:FontIcon Glyph=&#xE712;,
+                                  FontSize=16}"
+            Style="{StaticResource SubtleButtonStyle}"
+            ToolTipService.ToolTip="More options">
+            <Button.Flyout>
+                <MenuFlyout>
+                    <MenuFlyoutItem Click="ClearHistory_Click" Text="Clear history" />
+                </MenuFlyout>
+            </Button.Flyout>
+        </Button>
         <ItemsRepeater
             Grid.Row="1"
             IsTabStop="False"

--- a/AIDevGallery/Controls/DownloadProgressList.xaml.cs
+++ b/AIDevGallery/Controls/DownloadProgressList.xaml.cs
@@ -75,5 +75,16 @@ namespace AIDevGallery.Controls
                 App.ModelCache.AddModelToDownloadQueue(downloadableModel.ModelDetails);
             }
         }
+
+        private void ClearHistory_Click(object sender, RoutedEventArgs e)
+        {
+            foreach (DownloadableModel model in downloadProgresses.ToList())
+            {
+                if (model.Status is DownloadStatus.Completed or DownloadStatus.Canceled)
+                {
+                    downloadProgresses.Remove(model);
+                }
+            }
+        }
     }
 }

--- a/AIDevGallery/MainWindow.xaml
+++ b/AIDevGallery/MainWindow.xaml
@@ -167,7 +167,10 @@
                                     Width="32"
                                     Height="32"
                                     IsActive="False" />
-                                <FontIcon FontSize="14" Glyph="&#xE896;" />
+                                <FontIcon
+                                    AutomationProperties.AccessibilityView="Raw"
+                                    FontSize="14"
+                                    Glyph="&#xE896;" />
                             </Grid>
                         </Button.Content>
                         <Button.Flyout>


### PR DESCRIPTION
Like in Edge, there's now a 'Clear history' button to remove all cancelled and downloaded models from the list.

I did not put a clear button in each individual card as the icon might conflict with the "cancelled" button and we need to figure out how to deal with cancelled downloads (i.e. if the connection is lost, would it resume vs. start over)?



https://github.com/user-attachments/assets/35eb3a9e-28b4-4d74-aa4a-48cb8e9c2f53

