### PR TITLE
Removed uses of SemaphoreSlim in favor of ActionBlock.

### DIFF
--- a/AIDevGallery.Utils/AIDevGallery.Utils.csproj
+++ b/AIDevGallery.Utils/AIDevGallery.Utils.csproj
@@ -11,8 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-    <PackageReference Include="System.Text.Json"/>
-    <PackageReference Include="System.Memory"/>
+    <PackageReference Include="System.Text.Json" />
+    <PackageReference Include="System.Memory" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <PackageReference Include="PolySharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>build; analyzers</IncludeAssets>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.29.0-preview" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageVersion Include="System.Text.Json" Version="9.0.0" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="9.0.0" />
     <PackageVersion Include="System.Memory" Version="4.6.0" />
     <PackageVersion Include="PolySharp" Version="1.14.1" />
     <PackageVersion Include="Microsoft.ML.Tokenizers" Version="1.0.0" />


### PR DESCRIPTION
SemaphoreSlim was being used with non-blocking collections, so it would occasionally corrupt the lists.
ActionBlock is better suited for the specific behavior that was trying to be accomplished.
This considerably improved performance on model search and a little bit on model download.