### PR TITLE
feat(Chat): Enhance input and UI interactions

### DIFF
--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml
@@ -70,7 +70,8 @@
             Padding="-12,0,-12,24"
             ItemTemplateSelector="{StaticResource ChatTemplateSelector}"
             ItemsSource="{x:Bind Messages}"
-            SelectionMode="None">
+            SelectionMode="None"
+            Loaded="InvertedListView_Loaded">
             <ListView.ItemsPanel>
                 <ItemsPanelTemplate>
                     <ItemsStackPanel VerticalAlignment="Bottom" ItemsUpdatingScrollMode="KeepLastItemInView" />
@@ -92,21 +93,37 @@
                 Grid.Row="1"
                 AutomationProperties.Name="Prompt input"
                 KeyUp="TextBox_KeyUp"
-                PlaceholderText="Type your prompt" />
+                PlaceholderText="Enter your prompt (Press Shift + Enter to insert a newline)"
+                TextChanged="InputBox_TextChanged"
+                TextWrapping="Wrap" 
+                AcceptsReturn="True"
+                MaxHeight="148"
+                ScrollViewer.VerticalScrollBarVisibility="Auto"/>
             <StackPanel Grid.Column="1" Orientation="Horizontal">
-                <Button
-                    x:Name="SendBtn"
-                    AutomationProperties.Name="Send Message"
-                    Click="SendBtn_Click"
-                    Content="Send"
-                    Style="{StaticResource AccentButtonStyle}" />
-                <Button
-                    x:Name="StopBtn"
-                    AutomationProperties.Name="Stop"
-                    Click="StopBtn_Click"
-                    Content="Stop"
-                    Style="{ThemeResource AccentButtonStyle}"
-                    Visibility="Collapsed" />
+                <Button x:Name="SendBtn"
+                        AutomationProperties.Name="Send Message"
+                        Click="SendBtn_Click"
+                        Style="{StaticResource AccentButtonStyle}"
+                        IsEnabled="False">
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8">
+                        <FontIcon FontSize="16"
+                                  Glyph="&#xE725;" />
+                        <TextBlock Text="Send" />
+                    </StackPanel>
+                </Button>
+                <Button x:Name="StopBtn"
+                        AutomationProperties.Name="Stop"
+                        Click="StopBtn_Click"
+                        Style="{ThemeResource AccentButtonStyle}"
+                        Visibility="Collapsed">
+                    <StackPanel Orientation="Horizontal"
+                                Spacing="8">
+                        <FontIcon FontSize="16"
+                                  Glyph="&#xE73B;" />
+                        <TextBlock Text="Stop" />
+                    </StackPanel>
+                </Button>
             </StackPanel>
 
         </Grid>

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
@@ -156,7 +156,7 @@ internal sealed partial class Chat : BaseSamplePage
                 NarratorHelper.Announce(InputBox, "Content has finished generating.", "ChatDoneAnnouncementActivityId"); // <exclude-line>
                 StopBtn.Visibility = Visibility.Collapsed;
                 SendBtn.Visibility = Visibility.Visible;
-                EnableInputBoxWithPlaceholder()
+                EnableInputBoxWithPlaceholder();
             });
         });
     }

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.AI;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
 using System;
 using System.Collections.ObjectModel;
 using System.Linq;
@@ -47,6 +48,8 @@ internal sealed partial class Chat : BaseSamplePage
         this.InitializeComponent();
     }
 
+    private ScrollViewer? scrollViewer;
+
     protected override async Task LoadModelAsync(SampleNavigationParameters sampleParams)
     {
         model = await sampleParams.GetIChatClientAsync();
@@ -71,6 +74,7 @@ internal sealed partial class Chat : BaseSamplePage
     {
         StopBtn.Visibility = Visibility.Collapsed;
         SendBtn.Visibility = Visibility.Visible;
+        EnableInputBoxWithPlaceholder();
         cts?.Cancel();
         cts?.Dispose();
         cts = null;
@@ -78,7 +82,10 @@ internal sealed partial class Chat : BaseSamplePage
 
     private void TextBox_KeyUp(object sender, KeyRoutedEventArgs e)
     {
-        if (e.Key == Windows.System.VirtualKey.Enter && sender is TextBox)
+        if (e.Key == Windows.System.VirtualKey.Enter &&
+            !Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) &&
+            sender is TextBox &&
+            !string.IsNullOrWhiteSpace(InputBox.Text))
         {
             SendMessage();
         }
@@ -101,7 +108,7 @@ internal sealed partial class Chat : BaseSamplePage
             return;
         }
 
-        Messages.Add(new Message(text, DateTime.Now, ChatRole.User));
+        Messages.Add(new Message(text.Trim(), DateTime.Now, ChatRole.User));
         var contentStartedBeingGenerated = false; // <exclude-line>
         NarratorHelper.Announce(InputBox, "Generating response, please wait.", "ChatWaitAnnouncementActivityId"); // <exclude-line>>
 
@@ -115,6 +122,8 @@ internal sealed partial class Chat : BaseSamplePage
             {
                 Messages.Add(responseMessage);
                 StopBtn.Visibility = Visibility.Visible;
+                InputBox.IsEnabled = false;
+                InputBox.PlaceholderText = "Please wait for the response to complete before entering a new prompt";
             });
 
             cts = new CancellationTokenSource();
@@ -147,6 +156,7 @@ internal sealed partial class Chat : BaseSamplePage
                 NarratorHelper.Announce(InputBox, "Content has finished generating.", "ChatDoneAnnouncementActivityId"); // <exclude-line>
                 StopBtn.Visibility = Visibility.Collapsed;
                 SendBtn.Visibility = Visibility.Visible;
+                EnableInputBoxWithPlaceholder()
             });
         });
     }
@@ -159,5 +169,65 @@ internal sealed partial class Chat : BaseSamplePage
     private void StopBtn_Click(object sender, RoutedEventArgs e)
     {
         CancelResponse();
+    }
+
+    private void InputBox_TextChanged(object sender, TextChangedEventArgs e)
+    {
+        SendBtn.IsEnabled = !string.IsNullOrWhiteSpace(InputBox.Text);
+    }
+
+    private void EnableInputBoxWithPlaceholder()
+    {
+        InputBox.IsEnabled = true;
+        InputBox.PlaceholderText = "Enter your prompt (Press Shift + Enter to insert a newline)";
+    }
+
+    private void InvertedListView_Loaded(object sender, RoutedEventArgs e)
+    {
+        scrollViewer = FindElement<ScrollViewer>(InvertedListView);
+
+        ItemsStackPanel? itemsStackPanel = FindElement<ItemsStackPanel>(InvertedListView);
+        if (itemsStackPanel != null)
+        {
+            itemsStackPanel.SizeChanged += ItemsStackPanel_SizeChanged;
+        }
+    }
+
+    private void ItemsStackPanel_SizeChanged(object sender, SizeChangedEventArgs e)
+    {
+        if (scrollViewer != null)
+        {
+            bool isScrollbarVisible = scrollViewer.ComputedVerticalScrollBarVisibility == Visibility.Visible;
+
+            if (isScrollbarVisible)
+            {
+                InvertedListView.Padding = new Thickness(-12, 0, 12, 24);
+            }
+            else
+            {
+                InvertedListView.Padding = new Thickness(-12, 0, -12, 24);
+            }
+        }
+    }
+
+    private T? FindElement<T>(DependencyObject element)
+        where T : DependencyObject
+    {
+        if (element is T targetElement)
+        {
+            return targetElement;
+        }
+
+        for (int i = 0; i < VisualTreeHelper.GetChildrenCount(element); i++)
+        {
+            var child = VisualTreeHelper.GetChild(element, i);
+            var result = FindElement<T>(child);
+            if (result != null)
+            {
+                return result;
+            }
+        }
+
+        return null;
     }
 }

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
@@ -83,10 +83,21 @@ internal sealed partial class Chat : BaseSamplePage
     private void TextBox_KeyUp(object sender, KeyRoutedEventArgs e)
     {
         if (e.Key == Windows.System.VirtualKey.Enter &&
-            !Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift).HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) &&
+            !Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift)
+                .HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down) &&
             sender is TextBox &&
             !string.IsNullOrWhiteSpace(InputBox.Text))
         {
+            var cursorPosition = InputBox.SelectionStart;
+            var text = InputBox.Text;
+            if (cursorPosition > 0 && (text[cursorPosition - 1] == '\n' || text[cursorPosition - 1] == '\r'))
+            {
+                text = text.Remove(cursorPosition - 1, 1);
+                InputBox.Text = text;
+            }
+
+            InputBox.SelectionStart = cursorPosition - 1;
+
             SendMessage();
         }
     }


### PR DESCRIPTION
## Description
This pull request improves the chat UI by adding icons, managing input behavior, and adjusting layout interactions; the main changes are:
- Added icons for Send and Stop buttons.
- Disabled sending when the input box is empty or contains only white spaces.
- Disabled the input box while a response is in progress to prevent multiple messages being sent simultaneously.
- Trimmed prompted text to remove unnecessary leading and trailing white spaces.
- Enabled new line insertion with Shift + Enter, set a maximum height for the input box, and enabled scrolling when needed.
- Adjusted the padding of the ScrollViewer in InvertedListView when the scroll bar is visible.

## Screenshots
![img 1](https://github.com/user-attachments/assets/a650da7d-1f48-4fed-b2aa-b385e92306f0)
--
![img 2](https://github.com/user-attachments/assets/8c89222c-fa72-4ce6-b554-2ac215bee49b)
--
![img 3](https://github.com/user-attachments/assets/9f828c86-af9f-48d0-b8f8-b24eb3c16837)
--
![img 4](https://github.com/user-attachments/assets/8fcff826-5592-4001-9a3e-b97d37617515)
--
![img 5](https://github.com/user-attachments/assets/acd47653-aa60-4e7a-b986-92dfa0aa5820)
