### PR TITLE
Add File Type Filter to FolderPicker

### DIFF
--- a/AIDevGallery/Pages/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/ScenarioPage.xaml.cs
@@ -361,6 +361,7 @@ namespace AIDevGallery.Pages
                 {
                     var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
                     var picker = new FolderPicker();
+                    picker.FileTypeFilter.Add("*");
                     WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
                     var folder = await picker.PickSingleFolderAsync();
                     if (folder != null)


### PR DESCRIPTION
A line of code has been added that adds a file type filter to the `FolderPicker` object. The added line is `picker.FileTypeFilter.Add("*");`, which allows the folder picker to accept all file types. Closes #53 