### PR TITLE
[BUGBASH] #84: Fix stop tokens during LM cancellation.

### DIFF
--- a/AIDevGallery/Samples/SharedCode/GenAIModel.cs
+++ b/AIDevGallery/Samples/SharedCode/GenAIModel.cs
@@ -254,9 +254,9 @@ internal class GenAIModel : IChatClient, IDisposable
                 generator.GenerateNextToken();
                 part = tokenizerStream.Decode(generator.GetSequence(0)[^1]);
 
-                if (ct.IsCancellationRequested)
+                if (ct.IsCancellationRequested && stopTokensAvailable)
                 {
-                    part = "<|end|>";
+                    part = _template!.Stop!.Last();
                 }
 
                 stringBuilder.Append(part);


### PR DESCRIPTION
If cancellation is requested, GenAIModel will now add the correct stop token for each LLM instead of always using <|end|>