### PR TITLE
#81: Having download dialog open when model finishes downloaded causes app to become uninteractable

### DIFF
--- a/AIDevGallery/Controls/ModelSelectionControl.xaml.cs
+++ b/AIDevGallery/Controls/ModelSelectionControl.xaml.cs
@@ -523,4 +523,9 @@ internal partial class ModelSelectionControl : UserControl
             }
         }
     }
+
+    public void HideDownloadDialog()
+    {
+        DownloadDialog?.Hide();
+    }
 }

--- a/AIDevGallery/Pages/ScenarioPage.xaml
+++ b/AIDevGallery/Pages/ScenarioPage.xaml
@@ -138,7 +138,7 @@
                     <Run Text="Consider one of these to get started:" />
                 </TextBlock>
                 <controls:ModelSelectionControl
-                    x:Name="PlaceholderControl"
+                    x:Name="ModelSelectionPlaceholderControl"
                     Grid.Row="1"
                     MinWidth="360"
                     ModelCardVisibility="Visible"

--- a/AIDevGallery/Pages/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/ScenarioPage.xaml.cs
@@ -137,7 +137,7 @@ internal sealed partial class ScenarioPage : Page
         }
 
         modelSelectionControl.SetModels(models, initialModelToLoad);
-        UpdatePlaceholderControl();
+        UpdateModelSelectionPlaceholderControl();
     }
 
     private static ModelDetails? SelectLatestOrDefault(List<ModelDetails> models)
@@ -201,14 +201,14 @@ internal sealed partial class ScenarioPage : Page
         if ((sample.Model2Types == null && selectedModelDetails == null) ||
             (sample.Model2Types != null && (selectedModelDetails == null || selectedModelDetails2 == null)))
         {
-            UpdatePlaceholderControl();
+            UpdateModelSelectionPlaceholderControl();
 
             VisualStateManager.GoToState(this, "NoModelSelected", true);
             return;
         }
         else
         {
-            PlaceholderControl.HideDownloadDialog();
+            ModelSelectionPlaceholderControl.HideDownloadDialog();
             VisualStateManager.GoToState(this, "ModelSelected", true);
             ModelDropDown2.Visibility = Visibility.Collapsed;
 
@@ -238,15 +238,15 @@ internal sealed partial class ScenarioPage : Page
         }
     }
 
-    private void UpdatePlaceholderControl()
+    private void UpdateModelSelectionPlaceholderControl()
     {
         if (sample == null || (sample.Model2Types == null && selectedModelDetails == null))
         {
-            PlaceholderControl.SetModels(modelSelectionControl.Models);
+            ModelSelectionPlaceholderControl.SetModels(modelSelectionControl.Models);
         }
         else
         {
-            PlaceholderControl.SetModels(modelSelectionControl2.Models);
+            ModelSelectionPlaceholderControl.SetModels(modelSelectionControl2.Models);
         }
     }
 

--- a/AIDevGallery/Pages/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/ScenarioPage.xaml.cs
@@ -208,6 +208,7 @@ internal sealed partial class ScenarioPage : Page
         }
         else
         {
+            PlaceholderControl.HideDownloadDialog();
             VisualStateManager.GoToState(this, "ModelSelected", true);
             ModelDropDown2.Visibility = Visibility.Collapsed;
 


### PR DESCRIPTION
fixes #81 

Manually closing dialog when visual states change when a model becomes available.

Also updated name of that control to remove some ambiguity.