### PR TITLE
#51: Copy over sample specific asset files to exported samples

### DIFF
--- a/AIDevGallery.SourceGenerator/SamplesSourceGenerator.cs
+++ b/AIDevGallery.SourceGenerator/SamplesSourceGenerator.cs
@@ -307,6 +307,13 @@ internal class SamplesSourceGenerator : IIncrementalGenerator
                             nugetPackageReferences = nugetPackageReferencesRef.Value.Values.Select(v => (string)v.Value!).ToArray();
                         }
 
+                        string[]? assetFilenames = null;
+                        var assetFilenamesRef = attributeData.NamedArguments.FirstOrDefault(a => a.Key == "AssetFilenames");
+                        if(!assetFilenamesRef.Value.IsNull)
+                        {
+                            assetFilenames = assetFilenamesRef.Value.Values.Select(v => (string)v.Value!).ToArray();
+                        }
+
                         return new SampleModel(
                             Owner: typeSymbol.GetFullyQualifiedName(),
                             Name: name,
@@ -317,6 +324,7 @@ internal class SamplesSourceGenerator : IIncrementalGenerator
                             Icon: icon,
                             Scenario: scenario,
                             NugetPackageReferences: nugetPackageReferences,
+                            AssetFilenames: assetFilenames,
                             attributeData.GetLocation());
                     }
                     catch (Exception)
@@ -399,6 +407,10 @@ internal class SamplesSourceGenerator : IIncrementalGenerator
                         }
                     }
 
+                    var assetFilenames = sample.AssetFilenames != null && sample.AssetFilenames.Length > 0
+                        ? string.Join(", ", sample.AssetFilenames.Select(a => $"\"{a}\""))
+                        : string.Empty;
+
                     sourceBuilder.AppendLine(
                         $$""""""
                             new Sample
@@ -419,7 +431,8 @@ internal class SamplesSourceGenerator : IIncrementalGenerator
                                 Model1Types = GetModelTypesFrom(1, typeof({{sample.Owner}}))!,
                                 Model2Types = GetModelTypesFrom(2, typeof({{sample.Owner}})),
                                 SharedCode = GetSharedCodeFrom(typeof({{sample.Owner}})),
-                                NugetPackageReferences = [ {{nugetPackageReferences}} ]
+                                NugetPackageReferences = [ {{nugetPackageReferences}} ],
+                                AssetFilenames = [ {{assetFilenames}} ]
                             },
                         """""");
                 }
@@ -436,7 +449,7 @@ internal class SamplesSourceGenerator : IIncrementalGenerator
     }
 
     private record ScenarioModel(string EnumName, string ScenarioCategoryType, string Id, string Name, string Description);
-    private record SampleModel(string Owner, string Name, string PageType, string XAMLCode, string CSCode, string Id, string Icon, string? Scenario, string[]? NugetPackageReferences, Location? Location);
+    private record SampleModel(string Owner, string Name, string PageType, string XAMLCode, string CSCode, string Id, string Icon, string? Scenario, string[]? NugetPackageReferences, string[]? AssetFilenames, Location? Location);
     private record ModelDefinitionModel(string EnumName, string Parent, string Name, string Id, string Description, string Url, string HardwareAccelerator, long Size, string ParameterSize);
 }
 #pragma warning restore RS1035 // Do not use APIs banned for analyzers

--- a/AIDevGallery/Models/Samples.cs
+++ b/AIDevGallery/Models/Samples.cs
@@ -32,6 +32,7 @@ internal class Sample
     public string XAMLCode { get; init; } = null!;
     public List<Samples.SharedCodeEnum> SharedCode { get; init; } = null!;
     public List<string> NugetPackageReferences { get; init; } = null!;
+    public List<string> AssetFilenames { get; init; } = null!;
 }
 
 internal class ModelFamily

--- a/AIDevGallery/ProjectGenerator/Generator.cs
+++ b/AIDevGallery/ProjectGenerator/Generator.cs
@@ -267,6 +267,17 @@ internal partial class Generator
             }
         }
 
+        // Add Asset Files
+        foreach(string assetFilename in sample.AssetFilenames)
+        {
+            string fullAssetPath = Path.Join(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, "Assets", assetFilename);
+            string fullOutputAssetPath = Path.Combine(outputPath, "Assets", assetFilename);
+            if (Path.GetExtension(fullAssetPath) is ".jpg" or ".png")
+            {
+                File.Copy(fullAssetPath, fullOutputAssetPath);
+            }
+        }
+
         var csproj = Path.Join(outputPath, $"{safeProjectName}.csproj");
 
         // Add NuGet references

--- a/AIDevGallery/ProjectGenerator/Generator.cs
+++ b/AIDevGallery/ProjectGenerator/Generator.cs
@@ -270,7 +270,7 @@ internal partial class Generator
         // Add Asset Files
         foreach(string assetFilename in sample.AssetFilenames)
         {
-            string fullAssetPath = Path.Join(Windows.ApplicationModel.Package.Current.InstalledLocation.Path, "Assets", assetFilename);
+            string fullAssetPath = Path.Join(Package.Current.InstalledLocation.Path, "Assets", assetFilename);
             string fullOutputAssetPath = Path.Combine(outputPath, "Assets", assetFilename);
             if (Path.GetExtension(fullAssetPath) is ".jpg" or ".png")
             {

--- a/AIDevGallery/Samples/Attributes/GallerySampleAttribute.cs
+++ b/AIDevGallery/Samples/Attributes/GallerySampleAttribute.cs
@@ -17,4 +17,5 @@ internal sealed class GallerySampleAttribute : Attribute
     public ScenarioType Scenario { get; init; }
     public SharedCodeEnum[]? SharedCode { get; init; }
     public string[]? NugetPackageReferences { get; init; }
+    public string[]? AssetFilenames { get; init; }
 }

--- a/AIDevGallery/Samples/Open Source Models/Image Models/FFNet/SegmentStreets.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/FFNet/SegmentStreets.xaml.cs
@@ -34,6 +34,9 @@ namespace AIDevGallery.Samples.OpenSourceModels.FFNet;
         "Microsoft.ML.OnnxRuntime.DirectML",
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
+    AssetFilenames = [
+       "streetscape.png",
+    ],
     Id = "9b74acc0-a5f7-430f-bed0-958ffc063598",
     Icon = "\uE8B3")]
 internal sealed partial class SegmentStreets : BaseSamplePage

--- a/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
@@ -31,7 +31,7 @@ namespace AIDevGallery.Samples.OpenSourceModels.ObjectDetection.FasterRCNN;
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
     AssetFilenames = [
-        "team.jpg"
+        "pose_default.png"
     ],
     Name = "Faster RCNN Object Detection",
     Id = "9b74ccc0-f5f7-430f-bed0-758ffc063508",

--- a/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
@@ -30,6 +30,9 @@ namespace AIDevGallery.Samples.OpenSourceModels.ObjectDetection.FasterRCNN;
         "Microsoft.ML.OnnxRuntime.DirectML",
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
+    AssetFilenames = [
+        "team.jpg"
+    ],
     Name = "Faster RCNN Object Detection",
     Id = "9b74ccc0-f5f7-430f-bed0-758ffc063508",
     Icon = "\uE8B3")]

--- a/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/Faster RCNN/ObjectDetection.xaml.cs
@@ -54,7 +54,7 @@ internal sealed partial class ObjectDetection : BaseSamplePage
         sampleParams.NotifyCompletion();
 
         // Loads inference on default image
-        await DetectObjects(Windows.ApplicationModel.Package.Current.InstalledLocation.Path + "\\Assets\\team.jpg");
+        await DetectObjects(Windows.ApplicationModel.Package.Current.InstalledLocation.Path + "\\Assets\\pose_default.png");
     }
 
     // <exclude>

--- a/AIDevGallery/Samples/Open Source Models/Image Models/HRNetPose/PoseDetection.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/HRNetPose/PoseDetection.xaml.cs
@@ -32,6 +32,9 @@ namespace AIDevGallery.Samples.OpenSourceModels.HRNetPose;
         "Microsoft.ML.OnnxRuntime.DirectML",
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
+    AssetFilenames = [
+        "pose_default.png"
+    ],
     Name = "Pose Detection",
     Id = "9b74ccc0-f5f7-430f-bed0-712ffc063508",
     Icon = "\uE8B3")]

--- a/AIDevGallery/Samples/Open Source Models/Image Models/ImageNet/ImageClassification.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/ImageNet/ImageClassification.xaml.cs
@@ -32,6 +32,9 @@ namespace AIDevGallery.Samples.OpenSourceModels;
         SharedCodeEnum.BitmapFunctions,
         SharedCodeEnum.DeviceUtils
     ],
+    AssetFilenames = [
+        "team.jpg"
+    ],
     Name = "ImageNet Image Classification",
     Id = "09d73ba7-b877-45f9-9de6-41898ab4d339",
     Icon = "\uE8B9")]

--- a/AIDevGallery/Samples/Open Source Models/Image Models/MultiHRNetPose/Multipose.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/MultiHRNetPose/Multipose.xaml.cs
@@ -37,6 +37,9 @@ namespace AIDevGallery.Samples.OpenSourceModels.MultiHRNetPose;
         "Microsoft.ML.OnnxRuntime.DirectML",
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
+    AssetFilenames = [
+        "team.jpg"
+    ],
     Name = "Multiple Pose Detection",
     Id = "9b74ccc0-f5f7-430f-bed0-71211c063508",
     Icon = "\uE8B3")]

--- a/AIDevGallery/Samples/Open Source Models/Image Models/YOLOv4/YOLOObjectionDetection.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Image Models/YOLOv4/YOLOObjectionDetection.xaml.cs
@@ -32,6 +32,9 @@ namespace AIDevGallery.Samples.OpenSourceModels.YOLOv4;
         "Microsoft.ML.OnnxRuntime.DirectML",
         "Microsoft.ML.OnnxRuntime.Extensions"
     ],
+    AssetFilenames = [
+        "team.jpg"
+    ],
     Name = "YOLO Object Detection",
     Id = "9b74ccc0-15f7-430f-bed0-7581fd163508",
     Icon = "\uE8B3")]


### PR DESCRIPTION
Fixes #51 

Just made it so sample asset files are copied over on project export.

@azchohfi should probably look at this one since I was messing with the generator stuff.