### PR TITLE
#128 and #125: RAG Improvements

### DIFF
--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
@@ -10,33 +10,23 @@
     mc:Ignorable="d">
     <Grid Loaded="Grid_Loaded">
         <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
-        <Grid
-            x:Name="IndexPDFProgressStackPanel"
-            MaxWidth="480"
-            Margin="16"
-            Visibility="Collapsed">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <TextBlock
-                x:Name="IndexPDFProgressTextBlock"
-                Grid.Row="1"
-                Margin="4"
-                HorizontalAlignment="Center"
-                Style="{StaticResource CaptionTextBlockStyle}" />
-            <ProgressBar
-                x:Name="IndexPDFProgressBar"
-                Grid.Row="0"
-                Height="8"
-                Margin="12"
-                HorizontalAlignment="Stretch" />
-        </Grid>
-        <ScrollViewer x:Name="InformationSV" Grid.Row="1" Padding="16" Visibility="Collapsed">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="*" />
+            <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+        <Button 
+            x:Name="SelectNewPDFButton"
+            Grid.Column="1"
+            Content="Select PDF"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Top"
+            Click="SelectNewPDF_Click"
+            Margin="12"
+            Visibility="Collapsed"/>
+        <ScrollViewer x:Name="InformationSV" Padding="16" Visibility="Collapsed">
             <TextBlock TextWrapping="Wrap" AutomationProperties.Name="PDF Information">
                 <Run x:Name="PagesUsedRun" FontWeight="SemiBold" />
                 <LineBreak />
@@ -46,7 +36,8 @@
         </ScrollViewer>
         <Grid
             x:Name="ChatGrid"
-            Grid.Row="2"
+            Grid.Row="1"
+            Grid.ColumnSpan="2"
             Margin="12"
             ColumnSpacing="16"
             RowSpacing="8"
@@ -58,6 +49,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
             <Border
                 Grid.RowSpan="3"
@@ -67,7 +59,7 @@
                 BorderThickness="0,1,0,0" />
             <TextBox
                 x:Name="SearchTextBox"
-                Grid.RowSpan="2"
+                Grid.RowSpan="3"
                 VerticalAlignment="Stretch"
                 GotFocus="SearchTextBox_GotFocus"
                 LostFocus="SearchTextBox_LostFocus"
@@ -88,7 +80,7 @@
                 Grid.Column="1"
                 HorizontalAlignment="Stretch"
                 Click="ShowPDFPage_Click"
-                Content="Show page"
+                Content="Show Page"
                 IsEnabled="False" />
         </Grid>
         <Grid
@@ -130,7 +122,6 @@
                 Click="NextPageButton_Click">
                 <FontIcon FontSize="16" Glyph="&#xE76C;" />
             </Button>
-
             <Button
                 x:Name="ClosePdfButton"
                 ToolTipService.ToolTip="Close PDF" 
@@ -156,8 +147,7 @@
             <TextBlock
                 x:Name="PdfProblemTextBlock"
                 HorizontalAlignment="Center"
-                Grid.Row="0"
-                />
+                Grid.Row="0" />
             <Button
                 x:Name="IndexPDFButton"
                 ToolTipService.ToolTip="Select PDF"
@@ -171,12 +161,12 @@
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <ProgressRing
                         x:Name="LoadPDFProgressRing"
-                        Width="24"
-                        Height="24"
+                        Width="16"
+                        Height="16"
                         IsActive="false"
                         HorizontalAlignment="Center"
                         Visibility="Collapsed" />
-                    <TextBlock x:Name="IndexPDFText" Text="Select a PDF" />
+                    <TextBlock x:Name="IndexPDFText" Text="Select a PDF" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
         </Grid>

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
@@ -24,7 +24,7 @@
             HorizontalAlignment="Right"
             VerticalAlignment="Top"
             Click="SelectNewPDF_Click"
-            Margin="12"
+            Margin="12" Style="{StaticResource AccentButtonStyle}"
             Visibility="Collapsed"/>
         <ScrollViewer x:Name="InformationSV" Padding="16" Visibility="Collapsed">
             <TextBlock TextWrapping="Wrap" AutomationProperties.Name="PDF Information">

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
@@ -143,6 +143,7 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <TextBlock
                 x:Name="PdfProblemTextBlock"
@@ -169,6 +170,10 @@
                     <TextBlock x:Name="IndexPDFText" Text="Select a PDF" VerticalAlignment="Center" />
                 </StackPanel>
             </Button>
+            <StackPanel x:Name="ProgressPanel" HorizontalAlignment="Center" Grid.Row="2" Visibility="Collapsed" Spacing="8">
+                <ProgressBar x:Name="IndexingProgressBar" Width="250" Value="0"/>
+                <TextBlock x:Name="ProgressStatusTextBlock" HorizontalAlignment="Center"/>
+            </StackPanel>
         </Grid>
     </Grid>
 </samples:BaseSamplePage>

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
@@ -22,7 +22,6 @@ using UglyToad.PdfPig;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 using Windows.Storage.Streams;
-using WinUICommunity;
 
 namespace AIDevGallery.Samples.OpenSourceModels.SentenceEmbeddings.Embeddings;
 

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
@@ -59,7 +59,7 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
     private StorageFile? _pdfFile;
     private InMemoryRandomAccessStream? _inMemoryRandomAccessStream;
     private CancellationTokenSource? _cts;
-    private bool _isCancellable = false;
+    private bool _isCancellable;
 
     private List<uint>? selectedPages;
     private int selectedPageIndex = -1;


### PR DESCRIPTION
fixes #125 
fixes #128 

Summary of changes:
* Removed RAG indexing progress indicator as it wasn't updating the UI properly, only takes 5-10 seconds, and complicates the sample to have it in there
* Added a "Select PDF" button to the prompting view to allow users to select a new PDF without reloading the sample
* Moved key functions up in the source so that viewing the code shows you `IndexPDF()` and `DoRAG()` towards the top of the file.