### PR TITLE
Fix to stable diffusion GPU issue

### DIFF
--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
@@ -25,7 +25,7 @@ internal class VaeDecoder : IDisposable
     {
         // Run session and send the input data in to get inference output.
         using IDisposableReadOnlyCollection<DisposableNamedOnnxValue> output = vaeDecoderInferenceSession.Run(input);
-        var result = output[0].AsTensor<float>();
+        var result = output[0].AsTensor<float>().Clone();
 
         return result;
     }


### PR DESCRIPTION
Fixes: https://github.com/microsoft/ai-dev-gallery/issues/110

We were disposing a tensor and then trying to later access it. Cloning the tensor locks it in memory. 