### PR TITLE
Enabled self-contained builds when using preview versions of WinAppSDK.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,11 +42,11 @@ jobs:
         $manifest.Package.Identity.Version = '${{ env.GitBuildVersionSimple }}.0'
         $manifest.Save($manifestPath)
     - name: Restore dependencies
-      run: dotnet restore AIDevGallery.sln -r win-${{ matrix.dotnet-arch }} /p:Configuration=Release /p:Platform=${{ matrix.dotnet-arch }} /p:PublishReadyToRun=true
+      run: dotnet restore AIDevGallery.sln -r win-${{ matrix.dotnet-arch }} /p:Configuration=Release /p:Platform=${{ matrix.dotnet-arch }} /p:PublishReadyToRun=true /p:SelfContainedIfPreviewWASDK=true
     - name: Build
       run: |
         dotnet build AIDevGallery.Utils --no-restore /p:Configuration=Release
-        dotnet build AIDevGallery --no-restore -r win-${{ matrix.dotnet-arch }} -f net9.0-windows10.0.22621.0 /p:Configuration=Release /p:Platform=${{ matrix.dotnet-arch }} /p:AppxPackageDir="AppPackages/" /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundle=Never /p:GenerateAppxPackageOnBuild=true
+        dotnet build AIDevGallery --no-restore -r win-${{ matrix.dotnet-arch }} -f net9.0-windows10.0.22621.0 /p:Configuration=Release /p:Platform=${{ matrix.dotnet-arch }} /p:AppxPackageDir="AppPackages/" /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundle=Never /p:GenerateAppxPackageOnBuild=true /p:SelfContainedIfPreviewWASDK=true
     - name: Upload Artifact - MSIX
       uses: actions/upload-artifact@v4
       with:

--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -12,11 +12,11 @@ steps:
       $manifest.Package.Identity.Version = "$($env:GitBuildVersionSimple).0"
       $manifest.Save($manifestPath)
   displayName: Update Package Manifest Version
-- script: dotnet restore AIDevGallery.sln -r win-${{ parameters.dotnet_platform }} /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:PublishReadyToRun=true
+- script: dotnet restore AIDevGallery.sln -r win-${{ parameters.dotnet_platform }} /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:PublishReadyToRun=true /p:SelfContainedIfPreviewWASDK=true
   displayName: Restore dependencies - ${{ parameters.dotnet_platform }}
 - script: |
     dotnet build AIDevGallery.Utils --no-restore /p:Configuration=Release
-    dotnet build AIDevGallery --no-restore -r win-${{ parameters.dotnet_platform }} -f net9.0-windows10.0.22621.0 /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:AppxPackageDir="AppPackages/" /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundle=Never /p:GenerateAppxPackageOnBuild=true
+    dotnet build AIDevGallery --no-restore -r win-${{ parameters.dotnet_platform }} -f net9.0-windows10.0.22621.0 /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:AppxPackageDir="AppPackages/" /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundle=Never /p:GenerateAppxPackageOnBuild=true /p:SelfContainedIfPreviewWASDK=true
   displayName: Build - ${{ parameters.dotnet_platform }}
 - task: CopyFiles@2
   displayName: Copy MSIX Artifacts - ${{ parameters.dotnet_platform }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,4 +22,12 @@
   <PropertyGroup Condition="$(Configuration)=='Release'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+  <PropertyGroup>
+    <IsWindowsAppSDKPreRelease>
+      $([System.String]::Copy('$(Microsoft_WindowsAppSDK_Version)').Contains('-'))
+    </IsWindowsAppSDKPreRelease>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(IsWindowsAppSDKPreRelease) == 'true' And $(SelfContainedIfPreviewWASDK) == 'true'">
+    <WindowsAppSDKSelfContained>true</WindowsAppSDKSelfContained>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
There is a bug on WinAppSDK if selfcontained is turned on for both the main app and the tests, so we build self contained only on the main build, and not for the tests.