### PR TITLE
Added regex to replace MS Docs specific md callouts

### DIFF
--- a/AIDevGallery/Pages/ModelPage.xaml.cs
+++ b/AIDevGallery/Pages/ModelPage.xaml.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using AIDevGallery.Helpers;
@@ -130,11 +130,22 @@ internal sealed partial class ModelPage : Page
 
         if (!string.IsNullOrWhiteSpace(readmeContents))
         {
-            readmeContents = Regex.Replace(readmeContents, @"\A---\n[\s\S]*?---\n", string.Empty, RegexOptions.Multiline);
+            readmeContents = PreprocessMarkdown(readmeContents);
+
             markdownTextBlock.Text = readmeContents;
         }
 
         readmeProgressRing.IsActive = false;
+    }
+
+    private string PreprocessMarkdown(string markdown)
+    {
+        markdown = Regex.Replace(markdown, @"\A---\n[\s\S]*?---\n", string.Empty, RegexOptions.Multiline);
+        markdown = Regex.Replace(markdown, @"^>\s*\[!IMPORTANT\]", "> **ℹ️ Important:**", RegexOptions.Multiline);
+        markdown = Regex.Replace(markdown, @"^>\s*\[!NOTE\]", "> **❗ Note:**", RegexOptions.Multiline);
+        markdown = Regex.Replace(markdown, @"^>\s*\[!TIP\]", "> **💡 Tip:**", RegexOptions.Multiline);
+
+        return markdown;
     }
 
     private IEnumerable<ModelDetails> GetAllSampleDetails()


### PR DESCRIPTION
Fixes: [#185](https://github.com/microsoft/ai-dev-gallery/issues/185)

Problem: [!IMPORTANT], [!TIP], [!NOTE] are Microsoft docs specific markdown callouts. Github flavored md doesn't recognize these callouts.

Fix: use regex to replace the broken callouts
![image](https://github.com/user-attachments/assets/7cc7c329-6b86-4231-baab-44cfab649616)
![image](https://github.com/user-attachments/assets/6b604ee6-92d4-41e7-819b-1a84ec8f5cc4)
