### PR TITLE
Added .vsconfig to AIDevGallery, and to exported projects.

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,0 +1,4 @@
+{
+  "version": "1.0", 
+  "components": [ "Microsoft.VisualStudio.Workload.Universal" ] 
+}

--- a/AIDevGallery/ProjectGenerator/Generator.cs
+++ b/AIDevGallery/ProjectGenerator/Generator.cs
@@ -207,7 +207,7 @@ internal partial class Generator
 
         SampleProjectGeneratedEvent.Log(sample.Id, model1Id, model2Id, copyModelLocally);
 
-        string[] extensions = [".manifest", ".xaml", ".cs", ".appxmanifest", ".csproj", ".ico", ".png", ".json", ".pubxml", ".sln"];
+        string[] extensions = [".manifest", ".xaml", ".cs", ".appxmanifest", ".csproj", ".ico", ".png", ".json", ".pubxml", ".sln", ".vsconfig"];
 
         // Get all files from the template directory with the allowed extensions
         var files = Directory.GetFiles(templatePath, "*.*", SearchOption.AllDirectories).Where(file => extensions.Any(file.EndsWith));

--- a/AIDevGallery/ProjectGenerator/Template/.vsconfig
+++ b/AIDevGallery/ProjectGenerator/Template/.vsconfig
@@ -1,0 +1,4 @@
+{
+  "version": "1.0", 
+  "components": [ "Microsoft.VisualStudio.Workload.Universal" ] 
+}


### PR DESCRIPTION
This ensures the WinUI application development workload is suggested to be installed on generated projects, as well as on the app itself.