### PR TITLE
Icon has an a11y name, fixes a11y bug

### DIFF
--- a/AIDevGallery/Controls/ModelSelectionControl.xaml
+++ b/AIDevGallery/Controls/ModelSelectionControl.xaml
@@ -101,7 +101,7 @@
                                         </Grid>
                                     </toolkit:SettingsCard.Header>
                                     <toolkit:SettingsCard.HeaderIcon>
-                                        <ImageIcon AutomationProperties.AccessibilityView="Raw" Source="{x:Bind ModelDetails.Icon}" />
+                                        <ImageIcon AutomationProperties.AccessibilityView="Control" AutomationProperties.Name="Model source icon" Source="{x:Bind ModelDetails.Icon}" />
                                     </toolkit:SettingsCard.HeaderIcon>
                                     <toolkit:SettingsCard.Description>
                                         <StackPanel>
@@ -275,7 +275,7 @@
                                     </Grid>
                                 </toolkit:SettingsCard.Header>
                                 <toolkit:SettingsCard.HeaderIcon>
-                                    <ImageIcon AutomationProperties.AccessibilityView="Raw" Source="{x:Bind ModelDetails.Icon}" />
+                                    <ImageIcon AutomationProperties.AccessibilityView="Control" AutomationProperties.Name="Model source icon" Source="{x:Bind ModelDetails.Icon}" />
                                 </toolkit:SettingsCard.HeaderIcon>
                                 <toolkit:SettingsCard.Description>
                                     <StackPanel>
@@ -449,7 +449,8 @@
                                 </toolkit:SettingsCard.Resources>
                                 <toolkit:SettingsCard.HeaderIcon>
                                     <ImageIcon
-                                        AutomationProperties.AccessibilityView="Raw"
+                                        AutomationProperties.AccessibilityView="Control"
+                                        AutomationProperties.Name="Model source icon"
                                         Opacity="0.4"
                                         Source="{x:Bind ModelDetails.Icon}" />
                                 </toolkit:SettingsCard.HeaderIcon>


### PR DESCRIPTION
#189 

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/2ef853d7-c65d-478a-a3d2-40cfc5dab3e8" />
