### PR TITLE
Tweaks to WCR samples UX

### DIFF
--- a/AIDevGallery/Controls/SampleContainer.xaml
+++ b/AIDevGallery/Controls/SampleContainer.xaml
@@ -16,51 +16,6 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
-        <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup x:Name="ModelEnabledStates">
-                <VisualState x:Name="Default" />
-                <VisualState x:Name="Disabled">
-                    <VisualState.Setters>
-                        <Setter Target="warningInfoBar.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="SampleLoading">
-                    <VisualState.Setters>
-                        <Setter Target="loadingRingContainer.Visibility" Value="Visible" />
-                        <Setter Target="sampleLoadingProgressRing.IsActive" Value="True" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="WcrApiNotCompatible">
-                    <VisualState.Setters>
-                        <Setter Target="wcrModelUnavailable.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="WcrModelNeedsDownload">
-                    <VisualState.Setters>
-                        <Setter Target="wcrModelDownloaderHost.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="SampleLoaded">
-                    <VisualState.Setters>
-                        <Setter Target="SampleFrame.Visibility" Value="Visible" />
-                        <Setter Target="AIContentWarningPanel.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-            <VisualStateGroup x:Name="CodeStates">
-                <VisualState x:Name="HideCodePane">
-                    <VisualState.Setters>
-                        <Setter Target="CodeColumn.Width" Value="0" />
-                    </VisualState.Setters>
-                </VisualState>
-                <VisualState x:Name="ShowCodePane">
-                    <VisualState.Setters>
-                        <Setter Target="CodeGrid.Visibility" Value="Visible" />
-                        <Setter Target="CodeGridSplitter.Visibility" Value="Visible" />
-                    </VisualState.Setters>
-                </VisualState>
-            </VisualStateGroup>
-        </VisualStateManager.VisualStateGroups>
         <!--<TextBlock x:Name="descriptionTextBlock" TextWrapping="WrapWholeWords" />-->
         <Grid
             x:Name="SampleCard"
@@ -137,7 +92,7 @@
 
                 <StackPanel
                     x:Name="wcrModelUnavailable"
-                    Margin="48,-4,48,48"
+                    Margin="48,0,48,48"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Vertical"
@@ -229,5 +184,50 @@
                 </toolkitcontrols:GridSplitter.RenderTransform>
             </toolkitcontrols:GridSplitter>
         </Grid>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="ModelEnabledStates">
+                <VisualState x:Name="Default" />
+                <VisualState x:Name="Disabled">
+                    <VisualState.Setters>
+                        <Setter Target="warningInfoBar.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SampleLoading">
+                    <VisualState.Setters>
+                        <Setter Target="loadingRingContainer.Visibility" Value="Visible" />
+                        <Setter Target="sampleLoadingProgressRing.IsActive" Value="True" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="WcrApiNotCompatible">
+                    <VisualState.Setters>
+                        <Setter Target="wcrModelUnavailable.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="WcrModelNeedsDownload">
+                    <VisualState.Setters>
+                        <Setter Target="wcrModelDownloaderHost.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="SampleLoaded">
+                    <VisualState.Setters>
+                        <Setter Target="SampleFrame.Visibility" Value="Visible" />
+                        <Setter Target="AIContentWarningPanel.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup x:Name="CodeStates">
+                <VisualState x:Name="HideCodePane">
+                    <VisualState.Setters>
+                        <Setter Target="CodeColumn.Width" Value="0" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="ShowCodePane">
+                    <VisualState.Setters>
+                        <Setter Target="CodeGrid.Visibility" Value="Visible" />
+                        <Setter Target="CodeGridSplitter.Visibility" Value="Visible" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
     </Grid>
 </UserControl>

--- a/AIDevGallery/Samples/SharedCode/WcrApis/WcrModelDownloader.xaml
+++ b/AIDevGallery/Samples/SharedCode/WcrApis/WcrModelDownloader.xaml
@@ -5,9 +5,10 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Margin="-24,-24,-24,-44"
     mc:Ignorable="d">
 
-    <Grid Background="{ThemeResource SolidBackgroundFillColorBaseBrush}" CornerRadius="4">
+    <Grid Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}" CornerRadius="4">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
@@ -15,7 +16,7 @@
 
         <StackPanel
             x:Name="NotDownloadedContent"
-            Margin="48,-4,48,48"
+            Margin="24"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Orientation="Vertical"
@@ -66,7 +67,7 @@
 
         <StackPanel
             x:Name="errorContent"
-            Margin="48,-4,48,48"
+            Margin="24"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Orientation="Vertical"

--- a/AIDevGallery/Samples/WCRAPIs/BackgroundRemover.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/BackgroundRemover.xaml
@@ -20,15 +20,15 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-            BorderThickness="3"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="2"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Viewbox
                 x:Name="ImageViewbox"
                 Margin="-1"
                 VerticalAlignment="Stretch"
                 Stretch="Uniform">
-                <Grid>
+                <Grid CornerRadius="{ThemeResource OverlayCornerRadius}">
                     <Image x:Name="CanvasImage" PointerPressed="CanvasImage_PointerPressed" />
                     <Canvas x:Name="PointsCanvas" IsHitTestVisible="False" />
                 </Grid>

--- a/AIDevGallery/Samples/WCRAPIs/ImageDescription.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/ImageDescription.xaml
@@ -15,8 +15,8 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-            BorderThickness="3"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="2"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Viewbox
                 x:Name="ImageViewbox"

--- a/AIDevGallery/Samples/WCRAPIs/IncreaseFidelity.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/IncreaseFidelity.xaml
@@ -59,7 +59,7 @@
                     <controls:GridSplitter
                         x:Name="GridSplitter"
                         Grid.Column="1"
-                        Width="12"
+                        Width="16"
                         Padding="0"
                         HorizontalAlignment="Left"
                         BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"

--- a/AIDevGallery/Samples/WCRAPIs/IncreaseFidelity.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/IncreaseFidelity.xaml
@@ -12,13 +12,13 @@
 
     <Grid ColumnSpacing="24">
         <Grid.Resources>
-            <SolidColorBrush x:Key="SizerBaseBackground" Color="{StaticResource ControlFillColorDefault}" />
-            <SolidColorBrush x:Key="SizerBaseBackgroundPointerOver" Color="{StaticResource ControlFillColorSecondary}" />
-            <SolidColorBrush x:Key="SizerBaseBackgroundPressed" Color="{StaticResource ControlFillColorTertiary}" />
+            <SolidColorBrush x:Key="SizerBaseBackground" Color="{StaticResource ControlOnImageFillColorDefault}" />
+            <SolidColorBrush x:Key="SizerBaseBackgroundPointerOver" Color="{StaticResource ControlOnImageFillColorSecondary}" />
+            <SolidColorBrush x:Key="SizerBaseBackgroundPressed" Color="{StaticResource ControlOnImageFillColorTertiary}" />
         </Grid.Resources>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" MaxWidth="600" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="Auto" MinWidth="160" />
         </Grid.ColumnDefinitions>
         <Grid
             MinWidth="240"
@@ -26,8 +26,8 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-            BorderThickness="3"
+            BorderBrush="{ThemeResource SurfaceStrokeColorDefaultBrush}"
+            BorderThickness="2"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Viewbox
                 x:Name="ImageViewbox"
@@ -59,9 +59,11 @@
                     <controls:GridSplitter
                         x:Name="GridSplitter"
                         Grid.Column="1"
-                        Width="8"
+                        Width="12"
                         Padding="0"
                         HorizontalAlignment="Left"
+                        BorderBrush="{ThemeResource SurfaceStrokeColorFlyoutBrush}"
+                        BorderThickness="1,0,1,0"
                         ResizeBehavior="BasedOnAlignment"
                         ResizeDirection="Auto">
                         <controls:GridSplitter.RenderTransform>
@@ -90,7 +92,10 @@
                 Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
                 CornerRadius="{StaticResource ControlCornerRadius}">
                 <TextBlock>
-                    <Run FontSize="12" Text="New" /><LineBreak />
+                    <Run
+                        FontSize="12"
+                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                        Text="New" /><LineBreak />
                     <Run x:Name="ScaledDimensionsTxt" FontWeight="SemiBold" />
                 </TextBlock>
             </Grid>
@@ -102,8 +107,8 @@
                 VerticalAlignment="Bottom"
                 Background="{ThemeResource AcrylicBackgroundFillColorDefaultBrush}"
                 CornerRadius="{StaticResource ControlCornerRadius}">
-                <TextBlock TextAlignment="Right">
-                    <Run FontSize="12" Text="Original" /><LineBreak />
+                <TextBlock FontSize="12" TextAlignment="Right">
+                    <Run Foreground="{ThemeResource TextFillColorSecondaryBrush}" Text="Original" /><LineBreak />
                     <Run x:Name="OriginalDimensionsTxt" FontWeight="SemiBold" />
                 </TextBlock>
             </Grid>
@@ -133,6 +138,7 @@
         <StackPanel
             x:Name="OptionsPanel"
             Grid.Column="1"
+            HorizontalAlignment="Stretch"
             Orientation="Vertical"
             Spacing="8">
             <TextBlock>
@@ -141,7 +147,6 @@
             </TextBlock>
             <Slider
                 x:Name="ScaleSlider"
-                Width="164"
                 AutomationProperties.Name="Scale factor"
                 IsThumbToolTipEnabled="False"
                 Maximum="8"

--- a/AIDevGallery/Samples/WCRAPIs/TextRecognition.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/TextRecognition.xaml
@@ -16,14 +16,15 @@
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
-            BorderBrush="{ThemeResource AccentFillColorDefaultBrush}"
-            BorderThickness="3"
+            BorderBrush="{ThemeResource ControlStrongStrokeColorDefaultBrush}"
+            BorderThickness="2"
             CornerRadius="{StaticResource OverlayCornerRadius}">
             <Viewbox x:Name="ImageViewbox" MaxHeight="600">
                 <Grid
                     x:Name="PaneGrid"
                     HorizontalAlignment="Stretch"
-                    VerticalAlignment="Stretch">
+                    VerticalAlignment="Stretch"
+                    CornerRadius="{ThemeResource OverlayCornerRadius}">
                     <Image x:Name="ImageSrc" Stretch="Uniform" />
                     <Canvas
                         x:Name="RectCanvas"
@@ -75,7 +76,7 @@
                 <Button
                     x:Name="CopyTextButton"
                     Click="CopyText_Click"
-                    ToolTipService.ToolTip="Click on the text to copy that line to your clipboard"
+                    ToolTipService.ToolTip="Copy all text to clipboard"
                     Visibility="Collapsed">
                     <FontIcon FontSize="16" Glyph="&#xF0E3;" />
                 </Button>


### PR DESCRIPTION
- Minor styling tweaks (rounded corners on all images for WCR samples, WCR download/error/requirements dialog is not covering the entire samplecontainer)

- Closing by using a brush that is meant to be used for UI controls on top of images, so it should meet contrast requirements: https://github.com/microsoft/ai-dev-gallery/issues/230

Light:
![image](https://github.com/user-attachments/assets/2119f763-7ffd-46bc-a506-761e93273465)

![image](https://github.com/user-attachments/assets/430e38d6-18e0-4d12-8faa-73dcde10e503)



