### PR TITLE
RAG sample UX improvements

### DIFF
--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
@@ -1,44 +1,33 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <samples:BaseSamplePage
-    xmlns:samples="using:AIDevGallery.Samples"
     x:Class="AIDevGallery.Samples.OpenSourceModels.SentenceEmbeddings.Embeddings.RetrievalAugmentedGeneration"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:samples="using:AIDevGallery.Samples"
     mc:Ignorable="d">
-    <Grid Loaded="Grid_Loaded">
+    <Grid ColumnSpacing="24" Loaded="Grid_Loaded">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="480" />
         </Grid.ColumnDefinitions>
-        <Button 
-            x:Name="SelectNewPDFButton"
-            Grid.Column="1"
-            Content="Select PDF"
-            HorizontalAlignment="Right"
-            VerticalAlignment="Top"
-            Click="SelectNewPDF_Click"
-            Margin="12" Style="{StaticResource AccentButtonStyle}"
-            Visibility="Collapsed"/>
-        <ScrollViewer x:Name="InformationSV" Padding="16" Visibility="Collapsed">
-            <TextBlock TextWrapping="Wrap" AutomationProperties.Name="PDF Information">
-                <Run x:Name="PagesUsedRun" FontWeight="SemiBold" />
-                <LineBreak />
-                <LineBreak />
-                <Run x:Name="AnswerRun" />
-            </TextBlock>
+        <ScrollViewer x:Name="InformationSV" Visibility="Collapsed">
+            <TextBlock
+                x:Name="AnswerRun"
+                AutomationProperties.Name="PDF Information"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                TextWrapping="Wrap" />
+
         </ScrollViewer>
         <Grid
             x:Name="ChatGrid"
             Grid.Row="1"
-            Grid.ColumnSpan="2"
-            Margin="12"
-            ColumnSpacing="16"
+            ColumnSpacing="12"
             RowSpacing="8"
             Visibility="Collapsed">
             <Grid.ColumnDefinitions>
@@ -48,89 +37,105 @@
             <Grid.RowDefinitions>
                 <RowDefinition Height="*" />
                 <RowDefinition Height="*" />
-                <RowDefinition Height="*" />
             </Grid.RowDefinitions>
-            <Border
-                Grid.RowSpan="3"
-                Grid.ColumnSpan="2"
-                HorizontalAlignment="Stretch"
-                VerticalAlignment="Stretch"
-                BorderThickness="0,1,0,0" />
             <TextBox
                 x:Name="SearchTextBox"
                 Grid.RowSpan="3"
                 VerticalAlignment="Stretch"
                 GotFocus="SearchTextBox_GotFocus"
-                LostFocus="SearchTextBox_LostFocus"
                 KeyUp="TextBox_KeyUp"
+                LostFocus="SearchTextBox_LostFocus"
                 PlaceholderText="Search PDF..."
                 TextWrapping="Wrap" />
             <Button
-                x:Name="AskSLMButton"
+                x:Name="AnswerButton"
                 Grid.Column="1"
                 HorizontalAlignment="Stretch"
                 Click="AskSLMButton_Click"
-                Content="Answer"
                 IsEnabled="True"
-                Style="{StaticResource AccentButtonStyle}" />
+                Style="{StaticResource AccentButtonStyle}">
+                <StackPanel Orientation="Horizontal" Spacing="12">
+                    <ProgressRing
+                        x:Name="RAGProgressRing"
+                        Width="16"
+                        Height="16"
+                        HorizontalAlignment="Center"
+                        Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                        IsActive="false"
+                        Visibility="Collapsed" />
+                    <TextBlock
+                        x:Name="AnswerButtonLabel"
+                        VerticalAlignment="Center"
+                        Text="Answer" />
+                </StackPanel>
+            </Button>
             <Button
-                x:Name="ShowPDFPage"
+                x:Name="SelectNewPDFButton"
                 Grid.Row="1"
                 Grid.Column="1"
-                HorizontalAlignment="Stretch"
-                Click="ShowPDFPage_Click"
-                Content="Show Page"
-                IsEnabled="False" />
+                Click="SelectNewPDF_Click"
+                Content="Select PDF" />
         </Grid>
         <Grid
             x:Name="PdfImageGrid"
             Grid.RowSpan="3"
-            Grid.ColumnSpan="2"
-            Background="{ThemeResource SmokeFillColorDefaultBrush}"
+            Grid.Column="1"
+            Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
+            BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+            BorderThickness="1"
+            CornerRadius="{StaticResource OverlayCornerRadius}"
             Visibility="Collapsed">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="75" />
-                <ColumnDefinition Width="*" />
-                <ColumnDefinition Width="75" />
-            </Grid.ColumnDefinitions>
-            <Image
-                x:Name="PdfImage"
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <TextBlock
+                Margin="12"
+                HorizontalAlignment="Center"
+                TextAlignment="Center">
+                <Run FontWeight="SemiBold" Text="Pages used" /> <LineBreak />
+                <Run x:Name="PagesUsedRun" />
+            </TextBlock>
+            <ScrollView
+                Grid.Row="1"
                 Grid.Column="1"
-                Margin="0,16"
-                Stretch="Uniform"
-                Tapped="PdfImage_Tapped" />
+                MaxZoomFactor="4"
+                MinZoomFactor="1"
+                ZoomMode="Enabled">
+                <Image
+                    x:Name="PdfImage"
+                    Margin="16,0,16,16"
+                    Stretch="Uniform" />
+            </ScrollView>
             <Button
                 x:Name="PreviousPageButton"
-                ToolTipService.ToolTip="Previous page"
-                AutomationProperties.Name="Previous Page"
+                Grid.Row="1"
                 Grid.Column="0"
                 Margin="16"
-                HorizontalAlignment="Right"
+                Padding="6"
+                HorizontalAlignment="Left"
                 VerticalAlignment="Center"
-                Click="PreviousPageButton_Click">
+                AutomationProperties.Name="Previous Page"
+                Click="PreviousPageButton_Click"
+                CornerRadius="48"
+                Style="{StaticResource AccentButtonStyle}"
+                ToolTipService.ToolTip="Previous page">
                 <FontIcon FontSize="16" Glyph="&#xE76B;" />
             </Button>
             <Button
                 x:Name="NextPageButton"
-                ToolTipService.ToolTip="Next page"
-                AutomationProperties.Name="Next Page"
+                Grid.Row="1"
                 Grid.Column="2"
                 Margin="16"
-                HorizontalAlignment="Left"
-                VerticalAlignment="Center"
-                Click="NextPageButton_Click">
-                <FontIcon FontSize="16" Glyph="&#xE76C;" />
-            </Button>
-            <Button
-                x:Name="ClosePdfButton"
-                ToolTipService.ToolTip="Close PDF" 
-                AutomationProperties.Name="Close PDF"
-                Grid.Column="2"
-                Margin="16"
+                Padding="6"
                 HorizontalAlignment="Right"
-                VerticalAlignment="Top"
-                Click="ClosePdfButton_Click">
-                <FontIcon FontSize="16" Glyph="&#xE894;" />
+                VerticalAlignment="Center"
+                AutomationProperties.Name="Next Page"
+                Click="NextPageButton_Click"
+                CornerRadius="48"
+                Style="{StaticResource AccentButtonStyle}"
+                ToolTipService.ToolTip="Next page">
+                <FontIcon FontSize="16" Glyph="&#xE76C;" />
             </Button>
         </Grid>
         <Grid
@@ -146,32 +151,45 @@
             </Grid.RowDefinitions>
             <TextBlock
                 x:Name="PdfProblemTextBlock"
-                HorizontalAlignment="Center"
-                Grid.Row="0" />
+                Grid.Row="0"
+                HorizontalAlignment="Center" />
             <Button
                 x:Name="IndexPDFButton"
-                ToolTipService.ToolTip="Select PDF"
-                AutomationProperties.Name="Select PDF"
                 Grid.Row="1"
                 Margin="24"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
+                AutomationProperties.Name="Select PDF"
                 Click="IndexPDFButton_Click"
-                IsEnabled="False">
+                IsEnabled="False"
+                Style="{StaticResource AccentButtonStyle}"
+                ToolTipService.ToolTip="Select PDF">
                 <StackPanel Orientation="Horizontal" Spacing="12">
                     <ProgressRing
                         x:Name="LoadPDFProgressRing"
                         Width="16"
                         Height="16"
-                        IsActive="false"
                         HorizontalAlignment="Center"
+                        Foreground="{ThemeResource TextOnAccentFillColorPrimaryBrush}"
+                        IsActive="false"
                         Visibility="Collapsed" />
-                    <TextBlock x:Name="IndexPDFText" Text="Select a PDF" VerticalAlignment="Center" />
+                    <TextBlock
+                        x:Name="IndexPDFText"
+                        VerticalAlignment="Center"
+                        Text="Select a PDF" />
                 </StackPanel>
             </Button>
-            <StackPanel x:Name="ProgressPanel" HorizontalAlignment="Center" Grid.Row="2" Visibility="Collapsed" Spacing="8">
-                <ProgressBar x:Name="IndexingProgressBar" Width="250" Value="0"/>
-                <TextBlock x:Name="ProgressStatusTextBlock" HorizontalAlignment="Center"/>
+            <StackPanel
+                x:Name="ProgressPanel"
+                Grid.Row="2"
+                HorizontalAlignment="Center"
+                Spacing="8"
+                Visibility="Collapsed">
+                <ProgressBar
+                    x:Name="IndexingProgressBar"
+                    Width="250"
+                    Value="0" />
+                <TextBlock x:Name="ProgressStatusTextBlock" HorizontalAlignment="Center" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml
@@ -14,7 +14,7 @@
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
-            <ColumnDefinition Width="480" />
+            <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
         <ScrollViewer x:Name="InformationSV" Visibility="Collapsed">
             <TextBlock
@@ -73,6 +73,7 @@
                 x:Name="SelectNewPDFButton"
                 Grid.Row="1"
                 Grid.Column="1"
+                HorizontalAlignment="Stretch"
                 Click="SelectNewPDF_Click"
                 Content="Select PDF" />
         </Grid>
@@ -80,6 +81,7 @@
             x:Name="PdfImageGrid"
             Grid.RowSpan="3"
             Grid.Column="1"
+            Width="480"
             Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"
             BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
             BorderThickness="1"
@@ -111,7 +113,7 @@
                 x:Name="PreviousPageButton"
                 Grid.Row="1"
                 Grid.Column="0"
-                Margin="16"
+                Margin="8"
                 Padding="6"
                 HorizontalAlignment="Left"
                 VerticalAlignment="Center"
@@ -126,7 +128,7 @@
                 x:Name="NextPageButton"
                 Grid.Row="1"
                 Grid.Column="2"
-                Margin="16"
+                Margin="8"
                 Padding="6"
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
@@ -229,10 +229,9 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
         DispatcherQueue.TryEnqueue(() =>
         {
-            ShowPDFPage.IsEnabled = true;
             IndexPDFGrid.Visibility = Visibility.Collapsed;
             ChatGrid.Visibility = Visibility.Visible;
-            SelectNewPDFButton.Visibility = Visibility.Visible;
+            SelectNewPDFButton.IsEnabled = true;
         });
         _cts?.Dispose();
         _cts = null;
@@ -249,12 +248,16 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
         {
             _cts.Cancel();
             _cts = null;
-            AskSLMButton.Content = "Answer";
+            RAGProgressRing.IsActive = false;
+            RAGProgressRing.Visibility = Visibility.Collapsed;
+            AnswerButtonLabel.Text = "Answer";
             return;
         }
 
         selectedPageIndex = 0;
-        AskSLMButton.Content = "Cancel";
+        RAGProgressRing.IsActive = true;
+        RAGProgressRing.Visibility = Visibility.Visible;
+        AnswerButtonLabel.Text = "Cancel";
         SearchTextBox.IsEnabled = false;
         _cts = new CancellationTokenSource();
 
@@ -281,8 +284,9 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
         selectedPages = contents.Select(c => c.Page).ToList();
 
-        PagesUsedRun.Text = $"Using page(s) : {string.Join(", ", selectedPages)}";
+        PagesUsedRun.Text = string.Join(", ", selectedPages);
         InformationSV.Visibility = Visibility.Visible;
+        await UpdatePdfImageAsync();
 
         var pagesChunks = contents.GroupBy(c => c.Page)
             .Select(g => $"Page {g.Key}: {string.Join(' ', g.Select(c => c.Text))}");
@@ -312,7 +316,9 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
         _cts = null;
 
-        AskSLMButton.Content = "Answer";
+        RAGProgressRing.Visibility = Visibility.Collapsed;
+        RAGProgressRing.IsActive = false;
+        AnswerButtonLabel.Text = "Answer";
         SearchTextBox.IsEnabled = true;
     }
 
@@ -348,7 +354,7 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
             PdfImage.Source = bitmapImage;
             PdfImageGrid.Visibility = Visibility.Visible;
-            SelectNewPDFButton.Visibility = Visibility.Collapsed;
+          //  SelectNewPDFButton.Visibility = Visibility.Collapsed;
             UpdatePreviousAndNextPageButtonEnabled();
         });
     }
@@ -382,17 +388,6 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
         }
     }
 
-    private async void ShowPDFPage_Click(object sender, RoutedEventArgs e)
-    {
-        await UpdatePdfImageAsync().ConfigureAwait(false);
-    }
-
-    private void PdfImage_Tapped(object sender, TappedRoutedEventArgs e)
-    {
-        PdfImageGrid.Visibility = Visibility.Collapsed;
-        SelectNewPDFButton.Visibility = Visibility.Visible;
-    }
-
     private async void PreviousPageButton_Click(object sender, RoutedEventArgs e)
     {
         if (selectedPageIndex <= 0)
@@ -413,12 +408,6 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
         selectedPageIndex++;
         await UpdatePdfImageAsync().ConfigureAwait(false);
-    }
-
-    private void ClosePdfButton_Click(object sender, RoutedEventArgs e)
-    {
-        PdfImageGrid.Visibility = Visibility.Collapsed;
-        SelectNewPDFButton.Visibility = Visibility.Visible;
     }
 
     private IEnumerable<(string Text, uint Page)> SplitInChunks((string Text, uint Page) input, int maxLength)
@@ -474,14 +463,14 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
         _pdfPages?.DeleteCollectionAsync();
         HideProgress();
         _isCancellable = false;
-        ShowPDFPage.IsEnabled = false;
-        SelectNewPDFButton.Visibility = Visibility.Collapsed;
+        PdfImageGrid.Visibility = Visibility.Collapsed;
+        SelectNewPDFButton.IsEnabled = false;
         IndexPDFGrid.Visibility = Visibility.Visible;
         ChatGrid.Visibility = Visibility.Collapsed;
         IndexPDFButton.IsEnabled = true;
         LoadPDFProgressRing.IsActive = false;
         LoadPDFProgressRing.Visibility = Visibility.Collapsed;
-        IndexPDFText.Text = "Select PDF";
+        IndexPDFText.Text = "Select a PDF";
     }
 
     private void ToSelectingState()

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
@@ -354,7 +354,6 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
 
             PdfImage.Source = bitmapImage;
             PdfImageGrid.Visibility = Visibility.Visible;
-          //  SelectNewPDFButton.Visibility = Visibility.Collapsed;
             UpdatePreviousAndNextPageButtonEnabled();
         });
     }


### PR DESCRIPTION
Somewhat closing: https://github.com/microsoft/ai-dev-gallery/issues/140

- Loading indicator has been added to show that the SLM is processing.
- The PDF pages are now shown inline, and because it's using the new `ScrollView` control it allows for zooming in and out as well (using touchpad gestures, or ctrl+mouse scroll)

![RAG](https://github.com/user-attachments/assets/afd57c44-2224-4da3-8128-ccccfa91504e)
