### PR TITLE
Fix API deeplinking

### DIFF
--- a/AIDevGallery/Helpers/ActivationHelper.cs
+++ b/AIDevGallery/Helpers/ActivationHelper.cs
@@ -7,7 +7,6 @@ using AIDevGallery.Telemetry.Events;
 using Microsoft.Windows.AppLifecycle;
 using System.Linq;
 using Windows.ApplicationModel.Activation;
-using Windows.Data.Xml.Dom;
 
 namespace AIDevGallery.Helpers;
 

--- a/AIDevGallery/Helpers/ActivationHelper.cs
+++ b/AIDevGallery/Helpers/ActivationHelper.cs
@@ -7,6 +7,7 @@ using AIDevGallery.Telemetry.Events;
 using Microsoft.Windows.AppLifecycle;
 using System.Linq;
 using Windows.ApplicationModel.Activation;
+using Windows.Data.Xml.Dom;
 
 namespace AIDevGallery.Helpers;
 
@@ -24,7 +25,7 @@ internal static class ActivationHelper
 
                 DeepLinkActivatedEvent.Log(protocolArgs.Uri.ToString());
 
-                if (protocolArgs.Uri.Host == "models")
+                if (protocolArgs.Uri.Host == "models" || protocolArgs.Uri.Host == "apis")
                 {
                     var sampleModelTypes = App.FindSampleItemById(itemId);
 

--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -2,8 +2,10 @@
 // Licensed under the MIT License.
 
 using AIDevGallery.Controls;
+using AIDevGallery.Helpers;
 using AIDevGallery.Models;
 using AIDevGallery.Pages;
+using AIDevGallery.Samples;
 using AIDevGallery.Utils;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
@@ -12,6 +14,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Windows.Data.Xml.Dom;
 using Windows.System;
 using WinUIEx;
 
@@ -48,13 +51,29 @@ internal sealed partial class MainWindow : WindowEx
         {
             Navigate("Samples", obj);
         }
-        else if (obj is ModelType or List<ModelType>)
+        else if (obj is ModelType modelType)
         {
-            Navigate("Models", obj);
+            NavigateToApiOrModelPage(modelType);
+        }
+        else if (obj is List<ModelType> modelTypes && modelTypes.Count > 0)
+        {
+            NavigateToApiOrModelPage(modelTypes[0]);
         }
         else
         {
             Navigate("Home");
+        }
+    }
+
+    private void NavigateToApiOrModelPage(ModelType modelType)
+    {
+        if (ModelDetailsHelper.EqualOrParent(modelType, ModelType.WCRAPIs))
+        {
+            Navigate("APIs", modelType);
+        }
+        else
+        {
+            Navigate("Models", modelType);
         }
     }
 

--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -14,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using Windows.Data.Xml.Dom;
 using Windows.System;
 using WinUIEx;
 

--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -5,7 +5,6 @@ using AIDevGallery.Controls;
 using AIDevGallery.Helpers;
 using AIDevGallery.Models;
 using AIDevGallery.Pages;
-using AIDevGallery.Samples;
 using AIDevGallery.Utils;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;

--- a/AIDevGallery/Pages/APIs/APIPage.xaml
+++ b/AIDevGallery/Pages/APIs/APIPage.xaml
@@ -24,30 +24,38 @@
             <ColumnDefinition Width="*" />
             <ColumnDefinition Width="Auto" />
         </Grid.ColumnDefinitions>
-        <StackPanel
-            Margin="16,16,16,0"
-            Orientation="Horizontal"
-            Spacing="12">
-            <Image Width="24" Source="ms-appx:///Assets/ModelIcons/WCRAPI.svg" />
-            <TextBlock
-                Margin="0,-4,0,0"
-                VerticalAlignment="Center"
-                Style="{StaticResource SubtitleTextBlockStyle}"
-                Text="{x:Bind ModelFamily.Name}" />
-        </StackPanel>
         <Grid
             x:Name="ShadowCastGrid"
             Grid.RowSpan="5"
             Grid.ColumnSpan="5" />
-        <controls:CopyButton
-            Grid.Column="1"
-            Height="34"
-            HorizontalAlignment="Right"
-            AutomationProperties.Name="Copy link to page"
-            Click="CopyButton_Click"
-            Content="{ui:FontIcon Glyph=&#xE71B;,
-                                  FontSize=16}"
-            ToolTipService.ToolTip="Copy link to page" />
+        <Grid
+            Grid.ColumnSpan="2"
+            Margin="16,16,16,0"
+            ColumnSpacing="12">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="Auto" />
+            </Grid.ColumnDefinitions>
+            <Image Width="24" Source="ms-appx:///Assets/ModelIcons/WCRAPI.svg" />
+            <TextBlock
+                Grid.Column="1"
+                Margin="0,-4,0,0"
+                VerticalAlignment="Center"
+                Style="{StaticResource SubtitleTextBlockStyle}"
+                Text="{x:Bind ModelFamily.Name}" />
+            <controls:CopyButton
+                Grid.Column="2"
+                Height="34"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                AutomationProperties.Name="Copy link to page"
+                Click="CopyButton_Click"
+                Content="{ui:FontIcon Glyph=&#xE71B;,
+                                      FontSize=16}"
+                ToolTipService.ToolTip="Copy link to page" />
+        </Grid>
+
         <ScrollViewer
             x:Name="RootScroller"
             Grid.Row="1"
@@ -55,7 +63,7 @@
             VerticalAlignment="Stretch">
             <Grid
                 x:Name="ContentGrid"
-                Margin="0,16,16,16"
+                Margin="0,12,16,16"
                 ColumnSpacing="12"
                 RowSpacing="8">
                 <Grid.ColumnDefinitions>


### PR DESCRIPTION
This feels a bit like a band-aid fix.. we should probably refactor the whole navigation and deeplinking code.

For now, this PR fixes the linking to an API page since that was broken + a UI fix for the copylink button positioning

Steps to repro:
- Navigate to a WCR API page like OCR
- Click the copy button
- Paste the link in the run box
- AI Dev Gallery should launch and navigate to the OCR page


Other deeplinks to test:

_aidevgallery://apis/4bcc0137-0e9a-4eda-8096-b235fcb0e98b_

_aidevgallery://scenarios/generate-text_

_aidevgallery://models/phi4mini_