### PR TITLE
[BUGFIX] AI toolkit validation check fix

### DIFF
--- a/AIDevGallery/Pages/Models/ModelPage.xaml.cs
+++ b/AIDevGallery/Pages/Models/ModelPage.xaml.cs
@@ -178,7 +178,7 @@ internal sealed partial class ModelPage : Page
 
             foreach(AIToolkitAction action in modelDetails.AIToolkitActions)
             {
-                if(modelDetails.ValidateAction(action))
+                if(!modelDetails.ValidateAction(action))
                 {
                     continue;
                 }


### PR DESCRIPTION
AI Toolkit button was showing incompatible models, instead of the inverse.