### PR TITLE
Improve vertical spacing on the WCR API page

### DIFF
--- a/AIDevGallery/Pages/APIs/APIPage.xaml
+++ b/AIDevGallery/Pages/APIs/APIPage.xaml
@@ -15,7 +15,7 @@
     <Page.Resources>
         <tkconverters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Page.Resources>
-    <Grid x:Name="RootGrid" MaxWidth="1600">
+    <Grid x:Name="RootGrid" MaxWidth="1600" RowSpacing="8">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />


### PR DESCRIPTION
This PR improves the spacing between the "Export sample" `Button` and the `ScrollViewer`.

Currently it looks like this:

![image](https://github.com/user-attachments/assets/0de92e56-c79d-47e3-9a87-7e4f31acc2dd)
