### PR TITLE
[StableDiffusion Sample] Use same SD config object for all SD components

### DIFF
--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
@@ -47,9 +47,9 @@ internal class StableDiffusion : IDisposable
     {
         string tokenizerPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Assets", config.TokenizerModelPath);
 
-        textProcessor = await TextProcessing.CreateAsync(tokenizerPath, config.TextEncoderModelPath, policy, device, compileOption);
+        textProcessor = await TextProcessing.CreateAsync(config, tokenizerPath, config.TextEncoderModelPath, policy, device, compileOption);
         unetInferenceSession = await GetInferenceSession(config.UnetModelPath, policy, device, compileOption);
-        vaeDecoder = await VaeDecoder.CreateAsync(config.VaeDecoderModelPath, policy, device, compileOption);
+        vaeDecoder = await VaeDecoder.CreateAsync(config, config.VaeDecoderModelPath, policy, device, compileOption);
         safetyChecker = await SafetyChecker.CreateAsync(config.SafetyModelPath, policy, device, compileOption);
     }
 

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/TextProcessing.cs
@@ -14,15 +14,6 @@ namespace AIDevGallery.Samples.SharedCode.StableDiffusionCode;
 
 internal class TextProcessing : IDisposable
 {
-    private readonly StableDiffusionConfig config = new()
-    {
-        // Number of denoising steps
-        NumInferenceSteps = 15,
-
-        // Scale for classifier-free guidance
-        GuidanceScale = 7.5
-    };
-
     private InferenceSession? tokenizerInferenceSession;
     private InferenceSession? encoderInferenceSession;
     private bool disposedValue;
@@ -32,6 +23,7 @@ internal class TextProcessing : IDisposable
     }
 
     public static async Task<TextProcessing> CreateAsync(
+        StableDiffusionConfig config,
         string tokenizerPath,
         string encoderPath,
         ExecutionProviderDevicePolicy? policy,
@@ -39,12 +31,12 @@ internal class TextProcessing : IDisposable
         bool compileOption)
     {
         var instance = new TextProcessing();
-        instance.tokenizerInferenceSession = await instance.GetInferenceSession(tokenizerPath, policy, device, compileOption);
-        instance.encoderInferenceSession = await instance.GetInferenceSession(encoderPath, policy, device, compileOption);
+        instance.tokenizerInferenceSession = await instance.GetInferenceSession(config, tokenizerPath, policy, device, compileOption);
+        instance.encoderInferenceSession = await instance.GetInferenceSession(config, encoderPath, policy, device, compileOption);
         return instance;
     }
 
-    private Task<InferenceSession> GetInferenceSession(string modelPath, ExecutionProviderDevicePolicy? policy, string? device, bool compileOption)
+    private Task<InferenceSession> GetInferenceSession(StableDiffusionConfig config, string modelPath, ExecutionProviderDevicePolicy? policy, string? device, bool compileOption)
     {
         return Task.Run(async () =>
         {

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/VaeDecoder.cs
@@ -14,15 +14,6 @@ namespace AIDevGallery.Samples.SharedCode.StableDiffusionCode;
 
 internal class VaeDecoder : IDisposable
 {
-    private readonly StableDiffusionConfig config = new()
-    {
-        // Number of denoising steps
-        NumInferenceSteps = 15,
-
-        // Scale for classifier-free guidance
-        GuidanceScale = 7.5
-    };
-
     private InferenceSession? vaeDecoderInferenceSession;
     private bool disposedValue;
 
@@ -31,17 +22,18 @@ internal class VaeDecoder : IDisposable
     }
 
     public static async Task<VaeDecoder> CreateAsync(
+        StableDiffusionConfig config,
         string modelPath,
         ExecutionProviderDevicePolicy? policy,
         string? device,
         bool compileOption)
     {
         var instance = new VaeDecoder();
-        instance.vaeDecoderInferenceSession = await instance.GetInferenceSession(modelPath, policy, device, compileOption);
+        instance.vaeDecoderInferenceSession = await instance.GetInferenceSession(config, modelPath, policy, device, compileOption);
         return instance;
     }
 
-    private Task<InferenceSession> GetInferenceSession(string modelPath, ExecutionProviderDevicePolicy? policy, string? device, bool compileOption)
+    private Task<InferenceSession> GetInferenceSession(StableDiffusionConfig config, string modelPath, ExecutionProviderDevicePolicy? policy, string? device, bool compileOption)
     {
         return Task.Run(async () =>
         {


### PR DESCRIPTION
In PR #393 separate StableDiffusionConfig config dupe objects were created for the SD components. Here the config object created in StableDiffusion class is used across all the components.  