### PR TITLE
fix: dispose CancellationTokenSource to allow consecutive RAG queries

### DIFF
--- a/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/RetrievalAugmentedGeneration.xaml.cs
@@ -329,6 +329,9 @@ internal sealed partial class RetrievalAugmentedGeneration : BaseSamplePage
                         AnswerButtonLabel.Text = "Answer";
                         SearchTextBox.IsEnabled = true;
                     });
+
+                    _cts?.Dispose();
+                    _cts = null;
                 }
             });
     }


### PR DESCRIPTION
# fix: dispose CancellationTokenSource to allow consecutive RAG queries

## Summary

This PR addresses an issue in the `DoRAG` method where the `CancellationTokenSource` (`_cts`) was not being properly disposed or reset after execution. As a result, users were unable to perform consecutive retrieval-augmented generation (RAG) queries, since `_cts` remained non-null and would immediately cancel any subsequent attempt.

## Problem

- When `DoRAG()` is invoked, it checks whether `_cts != null` to determine if a cancellation is pending.
- If `_cts` is never disposed or reset after completion or cancellation, the method continues to short-circuit future RAG requests.
- This caused the UX to appear unresponsive or blocked after the first question was asked.

## Fix

- Added disposal and reset of `_cts` in the `finally` block of the background task launched by `Task.Run(...)`.
- The following lines were added to ensure correct cleanup:

  ```csharp
  _cts?.Dispose();
  _cts = null;
  ```

- This guarantees that the internal state is properly cleared after each request, allowing users to submit new questions without restarting the app.

- The disposal is done **outside of** `DispatcherQueue.TryEnqueue`, as it is not tied to UI thread operations and should not incur unnecessary context switching.

## Impact

- Enables expected behavior for consecutive RAG queries.
- Ensures proper resource cleanup and avoids potential memory leaks or threading issues.
- Brings the `DoRAG` method into alignment with cancellation token best practices.

## Validation

- Manually tested multiple RAG queries in sequence.
- Verified that the UI remains responsive and follow-up questions are processed correctly.
