### PR TITLE
[Fix]focus not moves to the tab items inside the code dropdown after …

### DIFF
--- a/AIDevGallery/Controls/SampleContainer.xaml
+++ b/AIDevGallery/Controls/SampleContainer.xaml
@@ -199,16 +199,21 @@
                             HorizontalScrollMode="Auto"
                             VerticalScrollBarVisibility="Auto"
                             ViewChanging="ScrollViewer_ViewChanging">
-                            <RichTextBlock
-                                x:Name="CodeTextBlock"
-                                Grid.Column="1"
-                                Padding="8,16"
-                                FontFamily="Consolas"
-                                FontSize="14"
-                                FontWeight="Light"
-                                IsTextSelectionEnabled="True"
-                                LineHeight="16"
-                                TextWrapping="NoWrap" />
+                            <Border 
+                                IsTabStop="True" 
+                                Background="Transparent" 
+                                x:Name="RichTextBlockBorder">
+                                <RichTextBlock
+                                    x:Name="CodeTextBlock"
+                                    Grid.Column="1"
+                                    Padding="8,16"
+                                    FontFamily="Consolas"
+                                    FontSize="14"
+                                    FontWeight="Light"
+                                    IsTextSelectionEnabled="True"
+                                    LineHeight="16"
+                                    TextWrapping="NoWrap" />
+                            </Border>
                         </ScrollViewer>
                     </Grid>
                 </Grid>

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -518,6 +518,7 @@ internal sealed partial class SampleContainer : UserControl
         }
 
         LineNumbersTextBlock.Text = lineNumbers.ToString();
+        RichTextBlockBorder.Focus(FocusState.Programmatic);
     }
 
     private void ScrollViewer_ViewChanging(object sender, ScrollViewerViewChangingEventArgs e)


### PR DESCRIPTION
Fix A11y bug , ADO 54123618

Actual Result:
focus not moves to the tab items inside the code dropdown.

i.e  while hitting tab from code dropdown, focus moving to name edit filed, after filling name edit field, focus moves to the tab items inside the code dropdown which is inappropriate keyboard behavior.

Expected Result:
Keyboard focus should move to the tab items inside the code dropdown.
after hitting tab from code dropdown.

User Impact:
Users who rely on keyboard will get difficulties if the focus does not move to the tab items inside the code dropdown after hitting tab from code dropdown.

<img width="1281" height="778" alt="image" src="https://github.com/user-attachments/assets/9c519d56-75e3-4132-83bb-185c68e79f63" />
