### PR TITLE
[Fix]The number of Suggestion is not announced by the narrator when s…

### DIFF
--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -225,7 +225,12 @@ internal sealed partial class MainWindow : WindowEx
         if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput && !string.IsNullOrWhiteSpace(SearchBox.Text))
         {
             var filteredSearchResults = App.SearchIndex.Where(sr => sr.Label.Contains(sender.Text, StringComparison.OrdinalIgnoreCase)).ToList();
-            SearchBox.ItemsSource = filteredSearchResults.OrderByDescending(i => i.Label.StartsWith(sender.Text, StringComparison.CurrentCultureIgnoreCase)).ThenBy(i => i.Label);
+            var orderedResults = filteredSearchResults.OrderByDescending(i => i.Label.StartsWith(sender.Text, StringComparison.CurrentCultureIgnoreCase)).ThenBy(i => i.Label).ToList();
+            SearchBox.ItemsSource = orderedResults;
+
+            var resultCount = orderedResults.Count;
+            string announcement = $"Searching for '{sender.Text}', {resultCount} search result{(resultCount == 1 ? string.Empty : 's')} found";
+            NarratorHelper.Announce(SearchBox, announcement, "searchSuggestionsActivityId");
         }
     }
 


### PR DESCRIPTION
Fix A11y bug, ADO 54147665.

Actual Result: 
while searching for something in search edit field, The displayed number of Suggestion are not announced by the narrator.
narrator just announcing as Suggestions when suggestions are displaying.

Expected Result: 
The number of Suggestion should be announced by the narrator when search suggestions are displaying in home tab.

User Impact: 
Users who rely on screen reader will be impacted if the number of suggestions is not announced.