### PR TITLE
Add Tooltip for Model Search Button

### DIFF
--- a/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
@@ -80,7 +80,8 @@
                         Content="{ui:FontIcon Glyph=&#xE721;,
                                               FontSize=16}"
                         IsEnabled="{Binding ElementName=SearchTextBox, Path=Text, Converter={StaticResource EmptyStringToObjectConverter}}"
-                        Style="{StaticResource AccentButtonStyle}" />
+                        Style="{StaticResource AccentButtonStyle}"
+                        ToolTipService.ToolTip="Search" />
                 </Grid>
             </StackPanel>
 


### PR DESCRIPTION
ADO #54174877

* Tooltip is not getting displayed for search icon in the Add Model page, while navigating using TAB key navigation.
* Repro Steps:
  - Navigate to Add Model button and invoke it
  - Navigate to Search a model edit field
  - Enter valid search text i.e Phi and Navigate to Search icon and observe

#### Before the fix:
<img width="1553" height="923" alt="image" src="https://github.com/user-attachments/assets/36905383-577e-4397-9f89-4da47107b508" />

#### After the fix:
<img width="1559" height="925" alt="image" src="https://github.com/user-attachments/assets/7a352b94-db32-40f7-adbc-04a895471fc9" />
