### PR TITLE
fix: 'The given key 'BulkRun' was not present in the dictionary.'

### DIFF
--- a/AIDevGallery.SourceGenerator/Models/AIToolkitAction.cs
+++ b/AIDevGallery.SourceGenerator/Models/AIToolkitAction.cs
@@ -10,6 +10,5 @@ internal enum AIToolkitAction
 {
     FineTuning,
     PromptBuilder,
-    BulkRun,
     Playground
 }

--- a/AIDevGallery/Models/Samples.cs
+++ b/AIDevGallery/Models/Samples.cs
@@ -189,7 +189,6 @@ internal enum AIToolkitAction
 {
     FineTuning,
     PromptBuilder,
-    BulkRun,
     Playground
 }
 


### PR DESCRIPTION
fix the bug in AIToolkitHelper.cs:
**System.Collections.Generic.KeyNotFoundException: 'The given key 'BulkRun' was not present in the dictionary.'**

This PR completes the cleanup of the BulkRun action from the AIToolkitAction enum. Although https://github.com/microsoft/ai-dev-gallery/pull/392 removed BulkRun from AIToolkitActions, some leftover references still exist in the codebase and may lead to runtime errors. This change ensures that all traces of BulkRun are fully removed to prevent unexpected behavior and improve code consistency.