### PR TITLE
fix warning button narrator bug

### DIFF
--- a/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
@@ -267,6 +267,7 @@
                                 Padding="0"
                                 VerticalAlignment="Top"
                                 AutomationProperties.Name="Warning"
+                                AutomationProperties.HelpText="{x:Bind Details.Compatibility.CompatibilityIssueDescription}"
                                 Style="{StaticResource SubtleButtonStyle}"
                                 ToolTipService.ToolTip="Warning"
                                 Visibility="{x:Bind VisibleWhenCompatibilityIssue}">


### PR DESCRIPTION
ADO bug report: #54185570

Actual Result:
Narrator is not announcing disabled information for not supported on the devices models in the Generate Text page.

Expected Result:
Narrator should announce disabled information for not supported on the devices models in the Generate Text page.