### PR TITLE
Clear and Rewrite buttons in Chat Sample

### DIFF
--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml
@@ -100,7 +100,20 @@
                 AcceptsReturn="True"
                 MaxHeight="148"
                 ScrollViewer.VerticalScrollBarVisibility="Auto"/>
-            <StackPanel Grid.Column="1" Orientation="Horizontal">
+            <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="8">
+                <Button x:Name="ClearBtn"
+                        AutomationProperties.Name="Clear Chat"
+                        Click="ClearBtn_Click"
+                        ToolTipService.ToolTip="Clear all messages">
+                    <FontIcon FontSize="16" Glyph="&#xE74D;" />
+                </Button>
+                <Button x:Name="RewriteBtn"
+                        AutomationProperties.Name="Rewrite Last Message"
+                        Click="RewriteBtn_Click"
+                        ToolTipService.ToolTip="Edit and resend last message"
+                        IsEnabled="False">
+                    <FontIcon FontSize="16" Glyph="&#xE70F;" />
+                </Button>
                 <Button x:Name="SendBtn"
                         AutomationProperties.Name="Send Message"
                         Click="SendBtn_Click"

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Chat.xaml.cs
@@ -67,6 +67,7 @@ internal sealed partial class Chat : BaseSamplePage
     private void Page_Loaded()
     {
         InputBox.Focus(FocusState.Programmatic);
+        UpdateRewriteButtonState();
     }
 
     // </exclude>
@@ -136,6 +137,7 @@ internal sealed partial class Chat : BaseSamplePage
         }
 
         Messages.Add(new Message(text.Trim(), DateTime.Now, ChatRole.User));
+        UpdateRewriteButtonState();
         var contentStartedBeingGenerated = false; // <exclude-line>
         NarratorHelper.Announce(InputBox, "Generating response, please wait.", "ChatWaitAnnouncementActivityId"); // <exclude-line>>
         SendSampleInteractedEvent("AddMessage"); // <exclude-line>
@@ -223,6 +225,16 @@ internal sealed partial class Chat : BaseSamplePage
         CancelResponse();
     }
 
+    private void ClearBtn_Click(object sender, RoutedEventArgs e)
+    {
+        ClearChat();
+    }
+
+    private void RewriteBtn_Click(object sender, RoutedEventArgs e)
+    {
+        RewriteLastMessage();
+    }
+
     private void InputBox_TextChanged(object sender, TextChangedEventArgs e)
     {
         SendBtn.IsEnabled = !string.IsNullOrWhiteSpace(InputBox.Text);
@@ -232,6 +244,32 @@ internal sealed partial class Chat : BaseSamplePage
     {
         InputBox.IsEnabled = true;
         InputBox.PlaceholderText = "Enter your prompt (Press Shift + Enter to insert a newline)";
+    }
+
+    private void ClearChat()
+    {
+        Messages.Clear();
+        UpdateRewriteButtonState();
+        SendSampleInteractedEvent("ClearChat"); // <exclude-line>
+    }
+
+    private void RewriteLastMessage()
+    {
+        var lastUserMessage = Messages.LastOrDefault(m => m.Role == ChatRole.User);
+        if (lastUserMessage != null)
+        {
+            InputBox.Text = lastUserMessage.Content;
+            InputBox.Focus(FocusState.Programmatic);
+
+            InputBox.SelectionStart = InputBox.Text.Length;
+            InputBox.SelectionLength = 0;
+            SendSampleInteractedEvent("RewriteLastMessage"); // <exclude-line>
+        }
+    }
+
+    private void UpdateRewriteButtonState()
+    {
+        RewriteBtn.IsEnabled = Messages.Any(m => m.Role == ChatRole.User);
     }
 
     private void InvertedListView_Loaded(object sender, RoutedEventArgs e)


### PR DESCRIPTION
#### Issue
https://github.com/microsoft/ai-dev-gallery/issues/388

#### Description

Introduce "Clear Chat" and "Rewrite Last Message" buttons to the chat UI, allowing users to clear all messages or edit and resend the last user message.

<img width="800" height="636" alt="image" src="https://github.com/user-attachments/assets/b09902b8-0c34-4611-8f69-d541b89489a4" />

 
**ToolTip of the buttons**
<img width="237" height="84" alt="image" src="https://github.com/user-attachments/assets/1a0b50a5-ffcc-419c-94d4-5e745d5db8c5" />
<img width="269" height="109" alt="image" src="https://github.com/user-attachments/assets/e729712c-5f07-4362-9d1e-dc95fb4c79b3" />


**Click the Rewrite Button**
<img width="907" height="773" alt="image" src="https://github.com/user-attachments/assets/7e88ba70-7b63-470d-a5e3-86f63588f895" />
