### PR TITLE
Run 'dotnet format' to align with .editorconfig

### DIFF
--- a/AIDevGallery/Controls/HomePage/SamplesCarousel.xaml.cs
+++ b/AIDevGallery/Controls/HomePage/SamplesCarousel.xaml.cs
@@ -54,7 +54,7 @@ internal partial class SamplesCarousel : UserControl
         }
 
         int i;
-        for(i = 0; i < description.Length; i++)
+        for (i = 0; i < description.Length; i++)
         {
             if (description[i] == '.')
             {

--- a/AIDevGallery/Controls/Markdown/MarkdownThemes.cs
+++ b/AIDevGallery/Controls/Markdown/MarkdownThemes.cs
@@ -57,9 +57,9 @@ internal sealed class MarkdownThemes : DependencyObject
 
     public Brush InlineCodeBorderBrush { get; set; } = (Brush)Application.Current.Resources["CardStrokeColorDefaultBrush"];
 
-    public Thickness InlineCodeBorderThickness { get; set; } = new (1);
+    public Thickness InlineCodeBorderThickness { get; set; } = new(1);
 
-    public CornerRadius InlineCodeCornerRadius { get; set; } = new (2);
+    public CornerRadius InlineCodeCornerRadius { get; set; } = new(2);
 
     public Thickness InlineCodePadding { get; set; } = new(0);
 

--- a/AIDevGallery/Controls/Markdown/Renderers/ObjectRenderers/Inlines/ContainerInlineRenderer.cs
+++ b/AIDevGallery/Controls/Markdown/Renderers/ObjectRenderers/Inlines/ContainerInlineRenderer.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-﻿using Markdig.Syntax.Inlines;
-﻿using System;
+using Markdig.Syntax.Inlines;
+using System;
 
-﻿namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers.ObjectRenderers.Inlines;
+namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers.ObjectRenderers.Inlines;
 
 internal class ContainerInlineRenderer : UWPObjectRenderer<ContainerInline>
 {

--- a/AIDevGallery/Controls/Markdown/Renderers/UWPObjectRenderer.cs
+++ b/AIDevGallery/Controls/Markdown/Renderers/UWPObjectRenderer.cs
@@ -1,10 +1,10 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-﻿using Markdig.Renderers;
-﻿using Markdig.Syntax;
+using Markdig.Renderers;
+using Markdig.Syntax;
 
-﻿namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers;
+namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.Renderers;
 
 internal abstract class UWPObjectRenderer<TObject> : MarkdownObjectRenderer<WinUIRenderer, TObject>
     where TObject : MarkdownObject

--- a/AIDevGallery/Controls/Markdown/TextElements/MyEmphasisInline.cs
+++ b/AIDevGallery/Controls/Markdown/TextElements/MyEmphasisInline.cs
@@ -67,11 +67,11 @@ internal class MyEmphasisInline : IAddChild
 
     public void SetBold()
     {
-        #if WINUI3
+#if WINUI3
         _span.FontWeight = Microsoft.UI.Text.FontWeights.Bold;
-        #elif WINUI2
+#elif WINUI2
         _span.FontWeight = Windows.UI.Text.FontWeights.Bold;
-        #endif
+#endif
 
         _isBold = true;
     }
@@ -84,11 +84,11 @@ internal class MyEmphasisInline : IAddChild
 
     public void SetStrikeThrough()
     {
-        #if WINUI3
+#if WINUI3
         _span.TextDecorations = Windows.UI.Text.TextDecorations.Strikethrough;
-        #elif WINUI2
+#elif WINUI2
         _span.TextDecorations = Windows.UI.Text.TextDecorations.Strikethrough;
-        #endif
+#endif
 
         _isStrikeThrough = true;
     }

--- a/AIDevGallery/Controls/Markdown/TextElements/MyImage.cs
+++ b/AIDevGallery/Controls/Markdown/TextElements/MyImage.cs
@@ -114,11 +114,11 @@ internal class MyImage : IAddChild
                     HttpResponseMessage response = await client.GetAsync(_uri);
 
                     // Get the Content-Type header
-    #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-    #pragma warning disable CS8602 // Dereference of a possibly null reference.
+#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning disable CS8602 // Dereference of a possibly null reference.
                     string contentType = response.Content.Headers.ContentType.MediaType;
-    #pragma warning restore CS8602 // Dereference of a possibly null reference.
-    #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
+#pragma warning restore CS8602 // Dereference of a possibly null reference.
+#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 
                     if (contentType == "image/svg+xml")
                     {

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml.cs
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml.cs
@@ -368,7 +368,7 @@ internal sealed partial class OnnxPickerView : BaseModelPickerView
 
             ResetAndLoadModelList();
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             ShowException(ex);
         }

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/WinAIApiPickerView.xaml.cs
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/WinAIApiPickerView.xaml.cs
@@ -62,7 +62,7 @@ internal sealed partial class WinAIApiPickerView : BaseModelPickerView
 
     public override void SelectModel(ModelDetails? modelDetails)
     {
-        if (modelDetails != null )
+        if (modelDetails != null)
         {
             var foundModel = models.FirstOrDefault(m => m.Id == modelDetails.Id);
             if (foundModel != null)

--- a/AIDevGallery/Helpers/ActivationHelper.cs
+++ b/AIDevGallery/Helpers/ActivationHelper.cs
@@ -77,7 +77,7 @@ internal static class ActivationHelper
     {
         var queryParams = HttpUtility.ParseQueryString(uri.Query);
 
-        if(!queryParams.AllKeys.Contains("modelPath") || !queryParams.AllKeys.Contains("scenarioId"))
+        if (!queryParams.AllKeys.Contains("modelPath") || !queryParams.AllKeys.Contains("scenarioId"))
         {
             return null;
         }
@@ -85,7 +85,7 @@ internal static class ActivationHelper
         string? modelPath = queryParams["modelpath"];
         Scenario? scenario = App.FindScenarioById(queryParams["scenarioId"] ?? string.Empty);
 
-        if(modelPath == null || scenario == null)
+        if (modelPath == null || scenario == null)
         {
             return null;
         }

--- a/AIDevGallery/Pages/Models/ModelPage.xaml.cs
+++ b/AIDevGallery/Pages/Models/ModelPage.xaml.cs
@@ -93,7 +93,7 @@ internal sealed partial class ModelPage : Page
             DocumentationCard.Visibility = Visibility.Collapsed;
         }
 
-        if(models.Count > 0)
+        if (models.Count > 0)
         {
             BuildAIToolkitButton();
         }
@@ -195,9 +195,9 @@ internal sealed partial class ModelPage : Page
     {
         Dictionary<AIToolkitAction, MenuFlyoutSubItem> actionSubmenus = new();
 
-        foreach(ModelDetails modelDetails in modelActionDict.Keys)
+        foreach (ModelDetails modelDetails in modelActionDict.Keys)
         {
-            foreach(AIToolkitAction action in modelActionDict[modelDetails])
+            foreach (AIToolkitAction action in modelActionDict[modelDetails])
             {
                 MenuFlyoutSubItem? actionFlyoutItem;
                 if (!actionSubmenus.TryGetValue(action, out actionFlyoutItem))
@@ -243,7 +243,7 @@ internal sealed partial class ModelPage : Page
 
     private void ToolkitActionFlyoutItem_Click(object sender, RoutedEventArgs e)
     {
-        if(sender is MenuFlyoutItem actionFlyoutItem)
+        if (sender is MenuFlyoutItem actionFlyoutItem)
         {
             (AIToolkitAction action, ModelDetails modelDetails) = ((AIToolkitAction, ModelDetails))actionFlyoutItem.Tag;
 

--- a/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
@@ -138,7 +138,7 @@ internal sealed partial class ScenarioPage : Page
 
         foreach (string device in WinMLHelpers.GetEpDeviceMap().Keys)
         {
-            switch(device)
+            switch (device)
             {
                 case "VitisAIExecutionProvider":
                     supportedHardwareAccelerators.Add(new([HardwareAccelerator.VitisAI, HardwareAccelerator.NPU], "VitisAIExecutionProvider", "VitisAI", "NPU"));

--- a/AIDevGallery/ProjectGenerator/Generator.cs
+++ b/AIDevGallery/ProjectGenerator/Generator.cs
@@ -553,7 +553,7 @@ internal partial class Generator
 
     internal void CleanUp()
     {
-        if(!string.IsNullOrEmpty(generatedProjectPath) && Directory.Exists(generatedProjectPath))
+        if (!string.IsNullOrEmpty(generatedProjectPath) && Directory.Exists(generatedProjectPath))
         {
             Directory.Delete(generatedProjectPath, true);
             generatedProjectPath = string.Empty;

--- a/AIDevGallery/Samples/BaseSamplePage.cs
+++ b/AIDevGallery/Samples/BaseSamplePage.cs
@@ -125,7 +125,7 @@ internal partial class BaseSamplePage : Page
 
         if (ex != null)
         {
-          exceptionDetails += GetExceptionDetails(ex);
+            exceptionDetails += GetExceptionDetails(ex);
         }
 
         DataPackage dataPackage = new DataPackage();

--- a/AIDevGallery/Samples/Open Source Models/Embeddings/SemanticSearch.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Embeddings/SemanticSearch.xaml.cs
@@ -196,7 +196,7 @@ internal sealed partial class SemanticSearch : BaseSamplePage
         {
             string sentence = sourceSentences[i];
 
-            if(sentence.Length > maxLength)
+            if (sentence.Length > maxLength)
             {
                 int indexOfLastSpace = sentence[0..maxLength].LastIndexOf(' ');
                 string firstSentenceChunk = sentence[0..indexOfLastSpace].Trim();

--- a/AIDevGallery/Samples/Open Source Models/Stable Diffusion/GenerateImage.xaml.cs
+++ b/AIDevGallery/Samples/Open Source Models/Stable Diffusion/GenerateImage.xaml.cs
@@ -85,7 +85,7 @@ internal sealed partial class GenerateImage : BaseSamplePage
             stableDiffusion = new StableDiffusion(parentFolder);
             await stableDiffusion.InitializeAsync(policy, epName, compileOption);
         }
-        catch(Exception ex)
+        catch (Exception ex)
         {
             ShowException(ex);
         }
@@ -234,7 +234,7 @@ internal sealed partial class GenerateImage : BaseSamplePage
         nint hwnd = WinRT.Interop.WindowNative.GetWindowHandle(new Window());
         FileSavePicker picker = new FileSavePicker
         {
-           SuggestedStartLocation = PickerLocationId.PicturesLibrary
+            SuggestedStartLocation = PickerLocationId.PicturesLibrary
         };
         WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
         picker.SuggestedFileName = "image.png";
@@ -242,7 +242,7 @@ internal sealed partial class GenerateImage : BaseSamplePage
 
         StorageFile file = await picker.PickSaveFileAsync();
 
-        if(file != null && DefaultImage.Source != null)
+        if (file != null && DefaultImage.Source != null)
         {
             SendSampleInteractedEvent("SaveFile"); // <exclude-line>
             RenderTargetBitmap renderTargetBitmap = new RenderTargetBitmap();

--- a/AIDevGallery/Samples/SharedCode/Controls/SmartTextBox.cs
+++ b/AIDevGallery/Samples/SharedCode/Controls/SmartTextBox.cs
@@ -301,7 +301,7 @@ internal sealed partial class SmartTextBox : Control
     private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
     {
         string text = (string)e.NewValue;
-        if(text != null)
+        if (text != null)
         {
             SmartTextBox smartTextBox = (SmartTextBox)d;
             smartTextBox._text = text;

--- a/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
+++ b/AIDevGallery/Samples/SharedCode/StableDiffusionCode/StableDiffusion.cs
@@ -166,7 +166,7 @@ internal class StableDiffusion : IDisposable
 
     public Bitmap? Inference(string prompt, CancellationToken token)
     {
-        if(unetInferenceSession == null || textProcessor == null || vaeDecoder == null || safetyChecker == null)
+        if (unetInferenceSession == null || textProcessor == null || vaeDecoder == null || safetyChecker == null)
         {
             throw new InvalidOperationException("StableDiffusion is not initialized.");
         }

--- a/AIDevGallery/Samples/SharedCode/WinMLHelpers.cs
+++ b/AIDevGallery/Samples/SharedCode/WinMLHelpers.cs
@@ -23,7 +23,7 @@ internal static class WinMLHelpers
         if (epDeviceMap.TryGetValue(epName, out var devices))
         {
             Dictionary<string, string> epOptions = new(StringComparer.OrdinalIgnoreCase);
-            switch(epName)
+            switch (epName)
             {
                 case "OpenVINOExecutionProvider":
                     // Configure threading for OpenVINO EP

--- a/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
@@ -206,7 +206,7 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
             LowRankAdaptation? loraAdapter;
             try
             {
-                 loraAdapter = _loraModel.LoadAdapter(_adapterFilePath);
+                loraAdapter = _loraModel.LoadAdapter(_adapterFilePath);
             }
             catch (Exception ex)
             {

--- a/AIDevGallery/Utils/AIToolkitHelper.cs
+++ b/AIDevGallery/Utils/AIToolkitHelper.cs
@@ -27,7 +27,7 @@ internal static class AIToolkitHelper
         string deeplink = "vscode://ms-windows-ai-studio.windows-ai-studio/";
         string modelId = action == AIToolkitAction.FineTuning ? modelDetails.AIToolkitFinetuningId! : modelDetails.AIToolkitId!;
 
-        if(aiToolkitActionInfos.TryGetValue(action, out actionInfo) && !string.IsNullOrEmpty(modelId))
+        if (aiToolkitActionInfos.TryGetValue(action, out actionInfo) && !string.IsNullOrEmpty(modelId))
         {
             deeplink = deeplink + $"{actionInfo.QueryName}?model_id={modelId}&track_from=AIDevGallery";
         }
@@ -47,12 +47,12 @@ internal static class AIToolkitHelper
 
     public static bool ValidateAction(this ModelDetails modelDetails, AIToolkitAction action)
     {
-        if(modelDetails.Compatibility.CompatibilityState == ModelCompatibilityState.NotCompatible)
+        if (modelDetails.Compatibility.CompatibilityState == ModelCompatibilityState.NotCompatible)
         {
             return false;
         }
 
-        if(action == AIToolkitAction.FineTuning)
+        if (action == AIToolkitAction.FineTuning)
         {
             return modelDetails.ValidateForFineTuning();
         }
@@ -76,13 +76,13 @@ internal static class AIToolkitHelper
             var actionsList = new List<AIToolkitAction>();
             foreach (AIToolkitAction action in details.AIToolkitActions)
             {
-                if(details.ValidateAction(action))
+                if (details.ValidateAction(action))
                 {
                     actionsList.Add(action);
                 }
             }
 
-            if(actionsList.Count > 0)
+            if (actionsList.Count > 0)
             {
                 validatedDetailsActionListMap.Add(details, actionsList);
             }

--- a/AIDevGallery/Utils/AppData.cs
+++ b/AIDevGallery/Utils/AppData.cs
@@ -152,12 +152,12 @@ internal class AppData
     {
         string modelTypeString = modelType.ToString();
 
-        if(ModelTypeToUserAddedModelsMapping is null)
+        if (ModelTypeToUserAddedModelsMapping is null)
         {
             ModelTypeToUserAddedModelsMapping = new Dictionary<string, List<string>>();
         }
 
-        if(ModelTypeToUserAddedModelsMapping.TryGetValue(modelTypeString, out List<string>? value))
+        if (ModelTypeToUserAddedModelsMapping.TryGetValue(modelTypeString, out List<string>? value))
         {
             value.Add(modelId);
         }
@@ -169,7 +169,7 @@ internal class AppData
 
     public async Task DeleteUserAddedModelMapping(string modelId)
     {
-        if(ModelTypeToUserAddedModelsMapping == null)
+        if (ModelTypeToUserAddedModelsMapping == null)
         {
             return;
         }

--- a/AIDevGallery/Utils/UserAddedModelUtil.cs
+++ b/AIDevGallery/Utils/UserAddedModelUtil.cs
@@ -141,7 +141,7 @@ internal static class UserAddedModelUtil
 
         if (file != null)
         {
-            if(App.ModelCache.IsModelCached($"local-file:///{file.Path}"))
+            if (App.ModelCache.IsModelCached($"local-file:///{file.Path}"))
             {
                 ContentDialog modelAlreadyAddedDialog = new()
                 {
@@ -304,9 +304,9 @@ internal static class UserAddedModelUtil
 
     public static bool IsModelsDetailsListUploadCompatible(this IEnumerable<ModelDetails> modelDetailsList)
     {
-        foreach(ModelDetails modelDetails in modelDetailsList)
+        foreach (ModelDetails modelDetails in modelDetailsList)
         {
-            if(modelDetails.InputDimensions != null && modelDetails.OutputDimensions != null)
+            if (modelDetails.InputDimensions != null && modelDetails.OutputDimensions != null)
             {
                 return true;
             }


### PR DESCRIPTION
This PR performs a repository-wide code formatting pass using dotnet format, based on the style rules defined in the existing .editorconfig file. While the configuration has been in place for some time, it appears that formatting enforcement had not been consistently applied, resulting in various style inconsistencies across the codebase.
**No functional changes are introduced in this PR**. **All modifications are purely stylistic and automated**, aiming to:

- Improve code readability and maintainability
- Ensure consistent formatting across all files
- Reduce noise in future diffs by aligning with the agreed-upon coding standards

This cleanup should make future contributions easier to review and help prevent formatting-related distractions during code reviews.