### PR TITLE
Restore UT execution for WinAppSDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,3 +120,21 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
     - name: Build Tests
       run: dotnet build AIDevGallery.UnitTests -r win-${{ matrix.dotnet-arch }} -f net9.0-windows10.0.26100.0 /p:Configuration=${{ matrix.dotnet-configuration }} /p:Platform=${{ matrix.dotnet-arch }}
+    - name: Run Tests
+      run: vstest.console.exe .\AIDevGallery.UnitTests\bin\${{ matrix.dotnet-arch }}\${{ matrix.dotnet-configuration }}\net9.0-windows10.0.26100.0\win-${{ matrix.dotnet-arch }}\AIDevGallery.UnitTests.exe /TestAdapterPath:"$HOME\.nuget\mstest.testadapter\3.9.2\buildTransitive\net9.0" /logger:"trx;LogFileName=${{ github.workspace }}\TestResults\VsTestResults.trx"
+    - name: Publish Test Builds If Failed
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-builds-${{ matrix.dotnet-arch }}
+        path: |
+            .\AIDevGallery\bin\${{ matrix.dotnet-arch }}\${{ matrix.dotnet-configuration }}
+            .\AIDevGallery\obj\${{ matrix.dotnet-arch }}\${{ matrix.dotnet-configuration }}
+            .\AIDevGallery.UnitTests\bin\${{ matrix.dotnet-arch }}\${{ matrix.dotnet-configuration }}
+            .\AIDevGallery.UnitTests\obj\${{ matrix.dotnet-arch }}\${{ matrix.dotnet-configuration }}
+    - name: Publish Test Results
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: test-results-${{ matrix.dotnet-arch }}
+        path: TestResults


### PR DESCRIPTION
## Background
In PR [#441](https://github.com/microsoft/ai-dev-gallery/pull/441), we temporarily disabled unit tests in the CI workflow and set `EnableMsixTooling=false` during the WinML to Windows App SDK migration. As a result, unit tests are currently not running in CI. This PR restores the test execution functionality with a more appropriate approach for Windows App SDK applications.

This PR restores the test execution functionality in unpackaged mode. Due to an existing bug in the Microsoft.Windows.SDK.BuildTools.MSIX package ([microsoft/WindowsAppSDK#5845](https://github.com/microsoft/WindowsAppSDK/issues/5845)), we cannot re-enable `EnableMsixTooling=true` at this time. This means packaged testing scenarios will need to wait for the upstream package bug fix.

## Summary
Re-enables unit test execution in the CI workflow with improved reliability and correct configuration for Windows App SDK applications running in unpackaged mode.

## Changes
- Run `AIDevGallery.UnitTests.exe` directly instead of using `.build.appxrecipe`
- Remove `/framework:FrameworkUap10` parameter

## Rationale

### 1. Using .exe Instead of .build.appxrecipe
The test project has `EnableMsixTooling=false` and is designed to run as an unpackaged Windows App SDK application. Running the `.exe` directly is more appropriate because:
- The unit test project doesn't require MSIX packaging
- Direct execution better matches the test project configuration
- It provides more straightforward test execution

### 2. Removing FrameworkUap10 Parameter
The `/framework:FrameworkUap10` parameter is specific to traditional UWP (Universal Windows Platform) applications. This project uses **Windows App SDK (WinUI 3)**, which is a different framework that doesn't require UWP-specific parameters. Using the wrong framework parameter could cause test execution issues.

## Testing Strategy
This approach aligns with best practices for Windows App SDK unit testing:
- **Unit tests** run in unpackaged mode (fast, tests application logic)
- **MSIX packaging** is validated separately in the `build` job
- Packaged testing scenarios (with `EnableMsixTooling=true`) will be re-evaluated once the upstream bug is fixed


## Related
- Partially restores functionality removed in #441
- Blocked on microsoft/WindowsAppSDK#5845 for packaged test scenarios