### PR TITLE
[Fix]A11y: Prevent UI truncation in portrait/narrow screen mode

### DIFF
--- a/AIDevGallery/Pages/APIs/APISelectionPage.xaml
+++ b/AIDevGallery/Pages/APIs/APISelectionPage.xaml
@@ -11,13 +11,13 @@
     <NavigationView
         x:Name="NavView"
         CompactModeThresholdWidth="0"
-        ExpandedModeThresholdWidth="0"
+        ExpandedModeThresholdWidth="1000"
         IsBackButtonVisible="Collapsed"
-        IsPaneOpen="True"
-        IsPaneToggleButtonVisible="False"
+        IsPaneToggleButtonVisible="True"
         IsPaneVisible="True"
         IsSettingsVisible="False"
         OpenPaneLength="224"
+        PaneDisplayMode="Auto"
         SelectionChanged="NavView_SelectionChanged">
         <NavigationView.Resources>
             <Thickness x:Key="NavigationViewContentGridBorderThickness">1,0,0,0</Thickness>

--- a/AIDevGallery/Pages/Scenarios/ScenarioSelectionPage.xaml
+++ b/AIDevGallery/Pages/Scenarios/ScenarioSelectionPage.xaml
@@ -10,13 +10,13 @@
     <NavigationView
         x:Name="NavView"
         CompactModeThresholdWidth="0"
-        ExpandedModeThresholdWidth="0"
+        ExpandedModeThresholdWidth="1000"
         IsBackButtonVisible="Collapsed"
-        IsPaneOpen="True"
-        IsPaneToggleButtonVisible="False"
+        IsPaneToggleButtonVisible="True"
         IsPaneVisible="True"
         IsSettingsVisible="False"
         OpenPaneLength="276"
+        PaneDisplayMode="Auto"
         SelectionChanged="NavView_SelectionChanged">
         <NavigationView.Resources>
             <Thickness x:Key="NavigationViewContentGridBorderThickness">1,0,0,0</Thickness>

--- a/AIDevGallery/Samples/Open Source Models/Stable Diffusion/GenerateImage.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Stable Diffusion/GenerateImage.xaml
@@ -13,6 +13,28 @@
             <RowDefinition Height="*"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
+        
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="NarrowLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="0" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="InputBox.(Grid.ColumnSpan)" Value="2" />
+                        <Setter Target="InputBox.Margin" Value="0,0,0,10" />
+                        <Setter Target="ButtonsPanel.(Grid.Row)" Value="1" />
+                        <Setter Target="ButtonsPanel.(Grid.ColumnSpan)" Value="2" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="WideLayout">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowWidth="800" />
+                    </VisualState.StateTriggers>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        
         <Image 
             x:Name="DefaultImage" 
             HorizontalAlignment="Center" 
@@ -21,31 +43,46 @@
             x:Name="Loader" 
             IsActive="false" 
             Visibility="Collapsed" />
-        <StackPanel 
+        <Grid 
+            x:Name="ControlsContainer"
             Grid.Row="1" 
-            Orientation="Horizontal" 
-            HorizontalAlignment="Center" 
-            Margin="0,20,0,0" 
-            Spacing="10">
+            HorizontalAlignment="Stretch"
+            Margin="20">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            
             <TextBox 
                 x:Name="InputBox" 
                 KeyUp="TextBox_KeyUp"
                 PreviewKeyDown="TextBox_PreviewKeyDown"
                 AutomationProperties.Name="Prompt input" 
                 PlaceholderText="Enter prompt to generate image" 
-                HorizontalAlignment="Center" 
-                Width="400"/>
-            <Button 
-                x:Name="GenerateButton" 
-                Click="GenerateButton_Click"
-                Style="{StaticResource AccentButtonStyle}"
-                Content="Generate" />
-            <Button
-                x:Name="SaveButton"
-                Click="SaveButton_Click"
-                Content="Save Image"
-                IsEnabled="False"/>
-        </StackPanel>
+                MinWidth="280"
+                Margin="0,0,10,0"/>
+            <StackPanel
+                x:Name="ButtonsPanel"
+                Grid.Column="1"
+                Orientation="Horizontal"
+                HorizontalAlignment="Right"
+                Spacing="10">
+                <Button 
+                    x:Name="GenerateButton" 
+                    Click="GenerateButton_Click"
+                    Style="{StaticResource AccentButtonStyle}"
+                    Content="Generate" />
+                <Button
+                    x:Name="SaveButton"
+                    Click="SaveButton_Click"
+                    Content="Save Image"
+                    IsEnabled="False"/>
+            </StackPanel>
+        </Grid>
         <ContentDialog 
             x:Name="ErrorDialog" 
             Title="Error"


### PR DESCRIPTION
Fixes accessibility issue(59169435) where input box and buttons were truncated in portrait orientation.

- Added responsive layout to GenerateImage page using VisualStateManager
- Input box now auto-stretches in both wide and narrow modes
- Navigation pane switches to compact mode on narrow screens
- Complies with WCAG 1.3.4 Orientation requirements
before:
<img width="368" height="610" alt="image" src="https://github.com/user-attachments/assets/f54cca2a-71cb-4db2-a4f4-1fd428b84d10" />

after:
<img width="368" height="510" alt="image" src="https://github.com/user-attachments/assets/d75229d0-3108-4153-bb3f-20467f52c449" />
