### PR TITLE
[Fix]FaceDetLite model download failure by using stable link

### DIFF
--- a/AIDevGallery/Samples/Definitions/Models/imagemodels.modelgroup.json
+++ b/AIDevGallery/Samples/Definitions/Models/imagemodels.modelgroup.json
@@ -323,7 +323,7 @@
           "FaceDetLite": {
             "Id": "b7cae123-478f-1177-9559-709df5dfe703",
             "Name": "FaceDetLite",
-            "Url": "https://huggingface.co/qualcomm/Lightweight-Face-Detection/blob/main/Lightweight-Face-Detection.onnx",
+            "Url": "https://huggingface.co/qualcomm/Lightweight-Face-Detection/resolve/v0.32.0/Lightweight-Face-Detection.onnx",
             "Description": "face_det_lite is a machine learning model that detect face in the images",
             "HardwareAccelerator": [
               "CPU",


### PR DESCRIPTION
This PR addresses an issue where downloading the FaceDetLite model in AI Dev Gallery fails with a “canceled” status.
<img width="383" height="68" alt="image" src="https://github.com/user-attachments/assets/a4c87ca9-88c8-443f-a9d3-382111f796aa" />

### Root Cause:
The remote download URL changed after version 0.33.0, making the current loading workflow incompatible.

### Temporary Solution:

Use a precise version-specific download link to ensure compatibility with AI Dev Gallery.
**Note: This link is not the latest model version, and future updates will not sync automatically.**

### Impact:

Restores model download functionality for the Detect Face sample.
Long-term fix will require updating the workflow to support dynamic URL changes.
