### PR TITLE
Fix resource disposal issues

### DIFF
--- a/AIDevGallery/Controls/Markdown/DefaultSVGRenderer.cs
+++ b/AIDevGallery/Controls/Markdown/DefaultSVGRenderer.cs
@@ -30,8 +30,10 @@ internal class DefaultSVGRenderer : ISVGRenderer
             memoryStream.Position = 0;
 
             // Load the SVG from the MemoryStream
-            // AsRandomAccessStream() returns an IDisposable that's owned by the SvgImageSource after SetSourceAsync
-            using var randomAccessStream = memoryStream.AsRandomAccessStream();
+            // AsRandomAccessStream() returns a wrapper that should not be disposed - it's owned by SvgImageSource after SetSourceAsync
+#pragma warning disable IDISP001 // Dispose created
+            var randomAccessStream = memoryStream.AsRandomAccessStream();
+#pragma warning restore IDISP001
             await svgImageSource.SetSourceAsync(randomAccessStream);
         }
 

--- a/AIDevGallery/Controls/Markdown/TextElements/MyImage.cs
+++ b/AIDevGallery/Controls/Markdown/TextElements/MyImage.cs
@@ -17,6 +17,7 @@ namespace CommunityToolkit.Labs.WinUI.MarkdownTextBlock.TextElements;
 
 internal class MyImage : IAddChild
 {
+    private static readonly HttpClient _httpClient = new HttpClient();
     private InlineUIContainer _container = new InlineUIContainer();
     private LinkInline? _linkInline;
     private Image _image = new Image();
@@ -108,10 +109,8 @@ internal class MyImage : IAddChild
             }
             else
             {
-                using HttpClient client = new();
-
                 // Download data from URL
-                using HttpResponseMessage response = await client.GetAsync(_uri);
+                using HttpResponseMessage response = await _httpClient.GetAsync(_uri);
 
                 // Get the Content-Type header
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -326,10 +326,6 @@ internal sealed partial class SampleContainer : UserControl, IDisposable
             _sampleLoadingCts = null;
         }
 
-        _sampleLoadedCompletionSource = null;
-        _sampleLoadingCts?.Dispose();
-        _sampleLoadingCts = null;
-
         NavigatedToSampleLoadedEvent.Log(sample.Name ?? string.Empty);
 
         VisualStateManager.GoToState(this, "SampleLoaded", true);


### PR DESCRIPTION
- Remove duplicate cleanup code in SampleContainer finally block
- Use static HttpClient in MyImage to prevent socket exhaustion
- Remove premature disposal of AsRandomAccessStream wrapper in DefaultSVGRenderer