### PR TITLE
feat: Auto Triage Notification

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -91,7 +91,13 @@ jobs:
           fi
 
           # Escape special characters for JSON
-          SAFE_TITLE=$(printf '%s' "$ISSUE_TITLE" | head -c 80 | jq -Rs '.')
+          MAX_TITLE_LENGTH=120
+          TITLE_FOR_TEAMS="$ISSUE_TITLE"
+          if [ "${#ISSUE_TITLE}" -gt "$MAX_TITLE_LENGTH" ]; then
+            TRUNCATED_TITLE=$(printf '%s' "$ISSUE_TITLE" | cut -c1-$((MAX_TITLE_LENGTH - 1)))
+            TITLE_FOR_TEAMS="${TRUNCATED_TITLE}..."
+          fi
+          SAFE_TITLE=$(printf '%s' "$TITLE_FOR_TEAMS" | jq -Rs '.')
           SAFE_LABELS=$(printf '%s' "${TRIAGE_LABELS:-none}" | jq -Rs '.')
           SAFE_SUMMARY_TEXT=$(printf '**Summary:** %s' "$TRIAGE_SUMMARY" | jq -Rs '.')
           CONFIDENCE_PCT=$(echo "$TRIAGE_CONFIDENCE" | awk '{printf "%.0f", $1 * 100}')


### PR DESCRIPTION
This pull request adds a new step to the issue triage workflow to notify the team via Microsoft Teams whenever an issue is successfully triaged and labels are applied. The notification includes key details about the issue and triage results.

### Integration with Microsoft Teams notifications

* Added a new workflow step to send an Adaptive Card notification to Microsoft Teams when an issue is triaged and labels are applied, using the `TEAMS_CHANNEL_WEBHOOK_URL` for authentication.
* The notification includes the issue number, title, applied labels, triage confidence as a percentage, and a summary, all formatted for Teams.