### PR TITLE
fix: Fix A11y Edit Field Narrator

### DIFF
--- a/AIDevGallery/Samples/SharedCode/Controls/SmartTextBox.cs
+++ b/AIDevGallery/Samples/SharedCode/Controls/SmartTextBox.cs
@@ -82,10 +82,11 @@ internal sealed partial class SmartTextBox : Control
     private void InputTextBox_GotFocus(object sender, RoutedEventArgs e)
     {
         // Announce text content for accessibility when the control receives focus
-        _inputTextBox!.Document.GetText(TextGetOptions.None, out string currentText);
+        var textBox = (RichEditBox)sender;
+        textBox.Document.GetText(TextGetOptions.None, out string currentText);
         if (!string.IsNullOrWhiteSpace(currentText))
         {
-            NarratorHelper.Announce(_inputTextBox, currentText.Trim(), "SmartTextBoxContentAnnouncement");
+            NarratorHelper.Announce(textBox, currentText.Trim(), "SmartTextBoxContentAnnouncement");
         }
     }
 


### PR DESCRIPTION
To fix #59151309. Enhances the accessibility of the `SmartTextBox` control by ensuring that screen readers like Narrator can announce the current text content.

**Accessibility improvements:**

* Added a handler for the `GotFocus` event on `_inputTextBox` to announce the current text content using `NarratorHelper.Announce` when the control receives focus. This ensures that users relying on assistive technologies are informed of the text present in the control.
<img width="779" height="156" alt="image" src="https://github.com/user-attachments/assets/fde2c068-95f9-4040-9651-76a49b421a9e" />
