### PR TITLE
Update build copy config

### DIFF
--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -34,8 +34,8 @@ steps:
         $sourceFolder = "$(System.DefaultWorkingDirectory)/AIDevGallery/AppPackages"
         $targetFolder = "$(Build.ArtifactStagingDirectory)/MSIX"
         New-Item -ItemType Directory -Path $targetFolder -Force | Out-Null
-        $files = Get-ChildItem -Path $sourceFolder -Recurse -Filter "AIDevGallery*_${{ parameters.dotnet_platform }}.msix" |
-          Where-Object { $_.DirectoryName -like "*_${{ parameters.dotnet_platform }}_Test*" }
+        $files = @(Get-ChildItem -Path $sourceFolder -Recurse -Filter "AIDevGallery*_${{ parameters.dotnet_platform }}.msix" |
+          Where-Object { $_.DirectoryName -like "*_${{ parameters.dotnet_platform }}_Test*" })
         foreach ($file in $files) {
           Write-Host "Copying: $($file.FullName)"
           Copy-Item -Path $file.FullName -Destination $targetFolder -Force


### PR DESCRIPTION
This pull request updates the build pipeline to handle MSIX artifact copying for the `arm64` platform. 

Platform-specific artifact copying:

* For non-`arm64` platforms, the pipeline continues to use the `CopyFiles@2` task to copy MSIX artifacts.
* For `arm64` builds, a new `PowerShell@2` task is used to locate and copy MSIX files.