### PR TITLE
fix: Fix Foundry Local exported project AppName validation error

### DIFF
--- a/AIDevGallery/Samples/SharedCode/IChatClient/FoundryLocalChatClientFactory.cs
+++ b/AIDevGallery/Samples/SharedCode/IChatClient/FoundryLocalChatClientFactory.cs
@@ -27,7 +27,7 @@ internal static class FoundryLocalChatClientFactory
             {
                 var config = new Configuration
                 {
-                    AppName = "AIDevGallery.FoundryLocalExportedSample"
+                    AppName = "AIDevGallery-FoundryLocalExportedSample"
                 };
 
                 try


### PR DESCRIPTION

## Root Cause
The `AppName` in `FoundryLocalChatClientFactory` was set to `"AIDevGallery.FoundryLocalExportedSample"`, which contains dots (`.`). The Foundry Local SDK validates that `AppName` only allows letters, numbers, spaces, hyphens, and underscores.

## Fix
Replace the dot separator with a hyphen: `"AIDevGallery-FoundryLocalExportedSample"`.