### PR TITLE
fix: Upgrade Microsoft.Windows.CsWin32 to 0.3.269 to fix SFI alert

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.251221100" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.205" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />
     <PackageVersion Include="System.Drawing.Common" Version="9.0.9" />
     <PackageVersion Include="NAudio.WinMM" Version="2.2.1" />
     <PackageVersion Include="System.Numerics.Tensors" Version="10.0.2" />


### PR DESCRIPTION
### Summary

Upgrade Microsoft.Windows.CsWin32 from 0.3.205 to 0.3.269 to resolve SFI alert ``MVS-2026-7756-87m4``

### Validation
Full solution restore: passed
Regression tests passed https://github.com/microsoft/ai-dev-gallery/actions/runs/24433175227