### PR TITLE
Windows ML 2.0 Upgrade

### DIFF
--- a/AIDevGallery.Tests/AIDevGallery.Tests.csproj
+++ b/AIDevGallery.Tests/AIDevGallery.Tests.csproj
@@ -59,6 +59,8 @@
     <ProjectReference Include="..\AIDevGallery\AIDevGallery.csproj" />
   </ItemGroup>
 
+  <Import Project="..\AIDevGallery\ExcludeExtraLibs.props" />
+
   <!-- 
     Defining the "HasPackageAndPublishMenuAddedByProject" property here allows the Solution 
     Explorer "Package and Publish" context menu entry to be enabled for this project even if 

--- a/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
+++ b/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
@@ -7,7 +7,6 @@ using FlaUI.Core.Tools;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Linq;
-using System.Threading;
 
 namespace AIDevGallery.Tests.AccessibilityTests;
 

--- a/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
+++ b/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
@@ -68,7 +68,10 @@ public class AccessibilityTests : FlaUITestBase
             if (pagesToDeepTest.Contains(pageName))
             {
                 // Act - Find scenario navigation view
-                var scenario = mainPage.FindFirstDescendant(cf => cf.ByAutomationId("ScenarioNavView"));
+                var scenarioResult = Retry.WhileNull(
+                    () => mainPage.FindFirstDescendant(cf => cf.ByAutomationId("ScenarioNavView")),
+                    timeout: TimeSpan.FromSeconds(10));
+                var scenario = scenarioResult.Result;
                 Assert.IsNotNull(scenario, "scenario should be found");
 
                 // Act - Find the MenuItemsHost in scenario navigation view
@@ -242,9 +245,17 @@ public class AccessibilityTests : FlaUITestBase
                 return !IsItemSelected(settingItem);
             },
             timeout: TimeSpan.FromSeconds(4));
-        navigationItem.Click();
+
+        // Click the target navigation item, retrying until it becomes the selected item.
+        Retry.WhileTrue(
+            () =>
+            {
+                navigationItem.Click();
+                return !IsItemSelected(navigationItem);
+            },
+            timeout: TimeSpan.FromSeconds(10),
+            throwOnTimeout: false);
         Console.WriteLine($"Clicked navigation item: {pageName}");
-        Thread.Sleep(2000); // Wait for page to load
         return true;
     }
 

--- a/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
+++ b/AIDevGallery.Tests/AccessibilityTests/AppPageTest.cs
@@ -69,8 +69,17 @@ public class AccessibilityTests : FlaUITestBase
                 // Act - Find scenario navigation view
                 var scenarioResult = Retry.WhileNull(
                     () => mainPage.FindFirstDescendant(cf => cf.ByAutomationId("ScenarioNavView")),
-                    timeout: TimeSpan.FromSeconds(10));
+                    timeout: TimeSpan.FromSeconds(30));
                 var scenario = scenarioResult.Result;
+                if (scenario == null)
+                {
+                    Console.WriteLine($"ScenarioNavView not found after navigating to {pageName}. Visible top-level descendants:");
+                    foreach (var d in MainWindow.FindAllDescendants().Take(30))
+                    {
+                        Console.WriteLine($"  - Name='{d.Name}' AutomationId='{d.AutomationId}' ControlType={d.ControlType}");
+                    }
+                }
+
                 Assert.IsNotNull(scenario, "scenario should be found");
 
                 // Act - Find the MenuItemsHost in scenario navigation view
@@ -245,13 +254,10 @@ public class AccessibilityTests : FlaUITestBase
             },
             timeout: TimeSpan.FromSeconds(4));
 
-        // Click the target navigation item, retrying until it becomes the selected item.
+        // Click the target navigation item, then wait until it becomes the selected item.
+        navigationItem.Click();
         Retry.WhileTrue(
-            () =>
-            {
-                navigationItem.Click();
-                return !IsItemSelected(navigationItem);
-            },
+            () => !IsItemSelected(navigationItem),
             timeout: TimeSpan.FromSeconds(10),
             throwOnTimeout: false);
         Console.WriteLine($"Clicked navigation item: {pageName}");

--- a/AIDevGallery/AIDevGallery.csproj
+++ b/AIDevGallery/AIDevGallery.csproj
@@ -350,10 +350,6 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsWindowsAppSDKPreRelease)' == 'true' And '$(SelfContainedIfPreviewWASDK)' == 'true'">
-    <None Include="$(PkgMicrosoft_WindowsAppSDK_AI)\runtimes-framework\win-$(Platform)\native\*.onnxe" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-  
   <!-- Exclude superfluous ORT and IHV libs when using Foundry Local WinML -->
   <Import Project="ExcludeExtraLibs.props"/>
   

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
@@ -41,7 +41,7 @@
                         Grid.Row="1"
                         TextWrapping="Wrap" 
                         Text="To use a custom model, convert it to a WindowsML-compatible format using the AI Toolkit conversion tool. Note: Currently, only select models are supported for conversion in AI Toolkit, with additional models coming soon." />
-                        <controls:WrapPanel Orientation="Horizontal" HorizontalSpacing="12" VerticalSpacing="12">
+                        <controls:WrapPanel Orientation="Horizontal" ItemSpacing="12" LineSpacing="12">
                             <Button
                             x:Name="OpenAIToolkitButton"
                             Click="OpenAIToolkitButton_Click"

--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -11,7 +11,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/AIDevGallery/Pages/APIs/APIOverview.xaml
+++ b/AIDevGallery/Pages/APIs/APIOverview.xaml
@@ -118,7 +118,7 @@
                         ItemsSource="{x:Bind wcrAPIs, Mode=OneWay}"
                         SelectionMode="None">
                         <ItemsView.Layout>
-                            <FlowLayout MinColumnSpacing="12" MinRowSpacing="12" />
+                            <FlowLayout MinItemSpacing="12" LineSpacing="12" />
                         </ItemsView.Layout>
                         <ItemsView.ItemTemplate>
                             <DataTemplate x:DataType="models:ApiDefinition">

--- a/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
+++ b/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
@@ -318,7 +318,7 @@ internal static class WcrApiCodeSnippet
         },
         {
             ModelType.SemanticSearch, """"
-            using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+            using Microsoft.Windows.Search.AppContentIndex;
 
             // This is some text data that we want to add to the index:
             Dictionary<string, string> simpleTextData = new Dictionary<string, string>
@@ -348,7 +348,7 @@ internal static class WcrApiCodeSnippet
                 AppContentIndexer indexer = GetIndexerForApp();
 
                 // We search the index using a semantic query:
-                AppIndexQuery queryCursor = indexer.CreateQuery("Facts about kittens.");
+                AppIndexTextQuery queryCursor = indexer.CreateTextQuery("Facts about kittens.");
                 IReadOnlyList<TextQueryMatch> textMatches = queryCursor.GetNextMatches(5);
 
                 // Nothing in the index exactly matches what we queried but item1 is similar to the query so we expect
@@ -401,8 +401,8 @@ internal static class WcrApiCodeSnippet
                 AppContentIndexer indexer = GetIndexerForApp();
 
                 // We query the index for some data to match our text query.
-                AppIndexQuery query = indexer.CreateQuery("cute pictures of kittens");
-                IReadOnlyList<ImageQueryMatch> imageMatches = query.GetImageMatches(5);
+                AppIndexImageQuery query = indexer.CreateImageQuery("cute pictures of kittens");
+                IReadOnlyList<ImageQueryMatch> imageMatches = query.GetNextMatches(5);
 
                 // One of the images that we indexed was a photo of a cat. We expect this to be the first match to match the query.
                 foreach (var match in imageMatches)
@@ -423,7 +423,7 @@ internal static class WcrApiCodeSnippet
         },
         {
             ModelType.KnowledgeRetrieval, """"
-            using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+            using Microsoft.Windows.Search.AppContentIndex;
             
             public void SimpleRAGScenario()
             {
@@ -441,8 +441,8 @@ internal static class WcrApiCodeSnippet
                 string userPrompt = Helpers.GetUserPrompt();
 
                 // We execute a query against the index using the user's prompt string as the query text.
-                AppIndexQuery query = indexer.CreateQuery(userPrompt);
-                IReadOnlyList<TextQueryMatch> textMatches = query.GetTextMatches(5);
+                AppIndexTextQuery query = indexer.CreateTextQuery(userPrompt);
+                IReadOnlyList<TextQueryMatch> textMatches = query.GetNextMatches(5);
 
                 StringBuilder promptStringBuilder = new StringBuilder();
                 promptStringBuilder.AppendLine("Please refer to the following pieces of information when responding to the user's prompt:");
@@ -474,7 +474,7 @@ internal static class WcrApiCodeSnippet
         },
         {
             ModelType.AppIndexCapability, """"
-            using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+            using Microsoft.Windows.Search.AppContentIndex;
 
             // Get index capabilities of current system
             public void SimpleCapabilitiesSample()

--- a/AIDevGallery/Samples/WCRAPIs/AppIndexCapability.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/AppIndexCapability.xaml.cs
@@ -4,7 +4,7 @@
 using AIDevGallery.Models;
 using AIDevGallery.Samples.Attributes;
 using Microsoft.UI.Xaml.Navigation;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -79,7 +79,7 @@ internal sealed partial class AppIndexCapability : BaseSamplePage
 
     private void CleanUp()
     {
-        _indexer?.RemoveAll();
+        _indexer?.RemoveAllContentItems();
         _indexer?.Dispose();
         _indexer = null;
     }

--- a/AIDevGallery/Samples/WCRAPIs/KnowledgeRetrieval.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/KnowledgeRetrieval.xaml.cs
@@ -10,7 +10,7 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -139,7 +139,7 @@ internal sealed partial class KnowledgeRetrieval : BaseSamplePage
     {
         CancelResponse();
         _model?.Dispose();
-        _indexer?.RemoveAll();
+        _indexer?.RemoveAllContentItems();
         _indexer?.Dispose();
         _indexer = null;
     }
@@ -621,7 +621,7 @@ internal sealed partial class KnowledgeRetrieval : BaseSamplePage
         }
 
         // Remove item from index
-        _indexer.Remove(id);
+        _indexer.RemoveContentItem(id);
     }
 
     private void IndexTextData(string id, string value)

--- a/AIDevGallery/Samples/WCRAPIs/SemanticSearch.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/SemanticSearch.xaml
@@ -186,10 +186,6 @@
                                         <ComboBoxItem Content="Region"/>
                                         <ComboBoxItem Content="ContentItem"/>
                                     </ComboBox>
-                                    <ComboBox x:Name="ImageOcrTextMatchTypeComboBox" Header="OCR Match Type" HorizontalAlignment="Stretch" SelectedIndex="0">
-                                        <ComboBoxItem Content="Fuzzy"/>
-                                        <ComboBoxItem Content="Exact"/>
-                                    </ComboBox>
 
                                     <Button Content="Index All Manually" Click="IndexAllButton_Click" Margin="0,24"/>
 

--- a/AIDevGallery/Samples/WCRAPIs/SemanticSearch.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/SemanticSearch.xaml.cs
@@ -8,7 +8,7 @@ using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Microsoft.UI.Xaml.Navigation;
-using Microsoft.Windows.AI.Search.Experimental.AppContentIndex;
+using Microsoft.Windows.Search.AppContentIndex;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -48,7 +48,7 @@ internal sealed partial class SemanticSearch : BaseSamplePage
     // This is some text data that we want to add to the index:
     private Dictionary<string, string> simpleTextData = new Dictionary<string, string>
     {
-        { "item1", "Preparing a hearty vegetable stew begins with chopping fresh carrots, onions, and celery. Sauté them in olive oil until fragrant, then add diced tomatoes, herbs, and vegetable broth. Simmer gently for an hour, allowing flavors to meld into a comforting dish perfect for cold evenings." },
+        { "item1", "Preparing a hearty vegetable stew begins with chopping fresh carrots, onions, and celery. SautÃ© them in olive oil until fragrant, then add diced tomatoes, herbs, and vegetable broth. Simmer gently for an hour, allowing flavors to meld into a comforting dish perfect for cold evenings." },
         { "item2", "Modern exhibition design combines narrative flow with spatial strategy. Lighting emphasizes focal objects while circulation paths avoid bottlenecks. Materials complement artifacts without visual competition. Interactive elements invite engagement but remain intuitive. Environmental controls protect sensitive works. Success balances scholarship, aesthetics, and visitor experience through thoughtful, cohesive design choices." },
         { "item3", "Domestic cats communicate through posture, tail flicks, and vocalizations. Play mimics hunting behaviors like stalking and pouncing, supporting agility and mental stimulation. Scratching maintains claws and marks territory, so provide sturdy posts. Balanced diets, hydration, and routine veterinary care sustain health. Safe retreats and vertical spaces reduce stress and encourage exploration." },
         { "item4", "Snowboarding across pristine slopes combines agility, balance, and speed. Riders carve smooth turns on powder, adjust stance for control, and master jumps in terrain parks. Essential gear includes boots, bindings, and helmets for safety. Embrace crisp alpine air while perfecting tricks and enjoying the thrill of winter adventure." },
@@ -127,7 +127,7 @@ internal sealed partial class SemanticSearch : BaseSamplePage
 
     private void CleanUp()
     {
-        _indexer?.RemoveAll();
+        _indexer?.RemoveAllContentItems();
         _indexer?.Dispose();
         _indexer = null;
     }
@@ -250,8 +250,7 @@ internal sealed partial class SemanticSearch : BaseSamplePage
         // Create image match options
         ImageQueryOptions imageQueryOptions = new ImageQueryOptions
         {
-            MatchScope = (QueryMatchScope)ImageMatchScopeComboBox.SelectedIndex,
-            ImageOcrTextMatchType = (TextLexicalMatchType)ImageOcrTextMatchTypeComboBox.SelectedIndex
+            MatchScope = (QueryMatchScope)ImageMatchScopeComboBox.SelectedIndex
         };
 
         CancellationToken ct = CancelGenerationAndGetNewToken();
@@ -467,7 +466,7 @@ internal sealed partial class SemanticSearch : BaseSamplePage
         }
 
         // Remove item from index
-        _indexer.Remove(id);
+        _indexer.RemoveContentItem(id);
     }
 
     private void IndexTextData(string id, string value)

--- a/AIDevGallery/Samples/WCRAPIs/VideoSuperRes.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/VideoSuperRes.xaml.cs
@@ -195,9 +195,9 @@ internal sealed partial class VideoSuperRes : BaseSamplePage
                 }
 
                 // Scale the frame using VideoScaler
-                var result = _videoScaler!.ScaleFrame(inputD3dSurface, _outputD3dSurface, new VideoScalerOptions());
+                var result = _videoScaler!.Scale(inputD3dSurface, _outputD3dSurface, new VideoScalerOptions());
 
-                if (result.Status == ScaleFrameStatus.Success)
+                if (result.Status == VideoScalerStatus.Success)
                 {
                     var outputBitmap = await SoftwareBitmap.CreateCopyFromSurfaceAsync(
                         _outputD3dSurface,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Media" Version="8.2.250402" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local.WinML" Version="0.8.2.1" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.2.0" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="2.0.28-experimental" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="2.0.325-experimental" />
     <PackageVersion Include="OllamaSharp" Version="5.4.7" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.2.0-preview.1.26063.2" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.72.0-preview" />
@@ -31,7 +31,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental3" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental7" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.251221100" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />


### PR DESCRIPTION
## Summary

Upgrades the Windows App SDK and Windows ML packages to the latest experimental release to adopt WinML 2.0.

| Package | Before | After |
| --- | --- | --- |
| `Microsoft.WindowsAppSDK` | `2.0.0-experimental3` | `2.0.0-experimental7` |
| `Microsoft.WindowsAppSDK.ML` | `2.0.28-experimental` | `2.0.325-experimental` |

## Changes

### Package versions
- `Directory.Packages.props`: bumped both packages to the versions above.

### Test project
- `AIDevGallery.Tests/AIDevGallery.Tests.csproj`: imports `..\AIDevGallery\ExcludeExtraLibs.props` so the test project picks up the same `onnxruntime.dll` dedup logic as the main app.

### App Content Search API renames

The `Microsoft.Windows.AI.Search.Experimental.AppContentIndex` namespace was renamed to `Microsoft.Windows.Search.AppContentIndex`, and a number of methods/types were renamed:

| Old | New |
| --- | --- |
| `Microsoft.Windows.AI.Search.Experimental.AppContentIndex` (namespace) | `Microsoft.Windows.Search.AppContentIndex` |
| `AppContentIndexer.RemoveAll()` | `AppContentIndexer.RemoveAllContentItems()` |
| `AppContentIndexer.Remove(id)` | `AppContentIndexer.RemoveContentItem(id)` |
| `AppContentIndexer.CreateQuery(text)` (text scenarios) | `AppContentIndexer.CreateTextQuery(text)` |
| `AppContentIndexer.CreateQuery(text)` (image scenarios) | `AppContentIndexer.CreateImageQuery(text)` |
| `AppIndexQuery` | `AppIndexTextQuery` / `AppIndexImageQuery` |
| `query.GetTextMatches(n)` / `query.GetImageMatches(n)` | `query.GetNextMatches(n)` |
| `ImageQueryOptions.ImageOcrTextMatchType` | *removed* |

Files updated:
- `AIDevGallery/MainWindow.xaml.cs`
- `AIDevGallery/Samples/WCRAPIs/AppIndexCapability.xaml.cs`
- `AIDevGallery/Samples/WCRAPIs/KnowledgeRetrieval.xaml.cs`
- `AIDevGallery/Samples/WCRAPIs/SemanticSearch.xaml` — removed the now-unused `ImageOcrTextMatchTypeComboBox`
- `AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs` — embedded code snippets updated to match the new API surface

### VideoScaler API renames

| Old | New |
| --- | --- |
| `VideoScaler.ScaleFrame(...)` | `VideoScaler.Scale(...)` |
| `ScaleFrameStatus` | `VideoScalerStatus` |

Files updated:
- `AIDevGallery/Samples/WCRAPIs/VideoSuperRes.xaml.cs`

### XAML layout property renames

| Control | Old | New |
| --- | --- | --- |
| `controls:WrapPanel` | `HorizontalSpacing` / `VerticalSpacing` | `ItemSpacing` / `LineSpacing` |
| `FlowLayout` | `MinColumnSpacing` / `MinRowSpacing` | `MinItemSpacing` / `LineSpacing` |

Files updated:
- `AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml`
- `AIDevGallery/Pages/APIs/APIOverview.xaml`

## Validation

- Clean rebuild on **x64** and **ARM64**.
- Manual smoke test of the affected samples (App Content Search — Lexical & Semantic Search, Knowledge Retrieval, App Index Capability; Video Super Resolution; Onnx model picker).