### PR TITLE
feat: VSR on CPU and upgrade Microsoft.WindowsAppSDK to 2.1.4-experim…

### DIFF
--- a/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
+++ b/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
@@ -52,7 +52,7 @@ internal static class WcrApiCodeSnippet
                 using LanguageModel languageModel = await LanguageModel.CreateAsync();
                 string adapterFilePath = "path_to_your_adapter_file";
                 LanguageModelLowRankAdapterResult adapterResult = LanguageModelLowRankAdapter.CreateFromPath(adapterFilePath);
-                LanguageModelLowRankAdapter loraAdapter = adapterResult.LowRankAdapter;
+                LanguageModelLowRankAdapter? loraAdapter = adapterResult.LowRankAdapter;
                 if (loraAdapter == null)
                 {
                     throw new Exception($"Could not create LanguageModelLowRankAdapter: {adapterResult.ExtendedError}");

--- a/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
+++ b/AIDevGallery/Samples/Definitions/WcrApis/WcrApiCodeSnippet.cs
@@ -42,7 +42,6 @@ internal static class WcrApiCodeSnippet
             ModelType.PhiSilicaLora, """"
             using Microsoft.Windows.AI;
             using Microsoft.Windows.AI.Text;
-            using Microsoft.Windows.AI.Text.Experimental;
             var readyState = LanguageModel.GetReadyState();
             if (readyState is AIFeatureReadyState.Ready or AIFeatureReadyState.NotReady)
             {
@@ -51,15 +50,19 @@ internal static class WcrApiCodeSnippet
                     var op = await LanguageModel.EnsureReadyAsync();
                 }
                 using LanguageModel languageModel = await LanguageModel.CreateAsync();
-                using LanguageModelExperimental loraModel = new LanguageModelExperimental(languageModel);
                 string adapterFilePath = "path_to_your_adapter_file";
-                LowRankAdaptation loraAdapter = loraModel.LoadAdapter(adapterFilePath);
-                var options = new LanguageModelOptionsExperimental
+                LanguageModelLowRankAdapterResult adapterResult = LanguageModelLowRankAdapter.CreateFromPath(adapterFilePath);
+                LanguageModelLowRankAdapter loraAdapter = adapterResult.LowRankAdapter;
+                if (loraAdapter == null)
                 {
-                    LoraAdapter = loraAdapter
+                    throw new Exception($"Could not create LanguageModelLowRankAdapter: {adapterResult.ExtendedError}");
+                }
+                var options = new LanguageModelOptions
+                {
+                    LowRankAdapter = loraAdapter
                 };
                 string prompt = "Provide the molecular formula for glucose.";
-                var result = await loraModel.GenerateResponseAsync(prompt, options);
+                var result = await languageModel.GenerateResponseAsync(prompt, options);
                 Console.WriteLine(result.Text);
             }
             """"

--- a/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
@@ -276,12 +276,22 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
                 {
                     case GenerationType.All:
                         options = LoadAdapter();
+                        if (options == null)
+                        {
+                            break;
+                        }
+
                         await Task.WhenAll(
                             GenerateText(InputTextBox.Text, SystemPromptBox.Text, LoraTxt, options),
                             GenerateText(InputTextBox.Text, SystemPromptBox.Text, NoLoraTxt));
                         break;
                     case GenerationType.With:
                         options = LoadAdapter();
+                        if (options == null)
+                        {
+                            break;
+                        }
+
                         await GenerateText(InputTextBox.Text, SystemPromptBox.Text, LoraTxt, options);
                         break;
                     case GenerationType.Without:

--- a/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
+++ b/AIDevGallery/Samples/WCRAPIs/PhiSilicaLoRa.xaml.cs
@@ -10,7 +10,6 @@ using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.AI;
 using Microsoft.Windows.AI.Text;
-using Microsoft.Windows.AI.Text.Experimental;
 using System;
 using System.IO;
 using System.Threading;
@@ -45,7 +44,6 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
     private const int MaxLength = 1000;
     private bool _isProgressVisible;
     private LanguageModel? _languageModel;
-    private LanguageModelExperimental? _loraModel;
 
     private CancellationTokenSource? _cts;
     private IAsyncOperationWithProgress<LanguageModelResponseResult, string>? operation;
@@ -98,7 +96,6 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
             }
 
             _languageModel = await LanguageModel.CreateAsync();
-            _loraModel = new LanguageModelExperimental(_languageModel);
         }
         else
         {
@@ -158,9 +155,9 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
         }
     }
 
-    public async Task GenerateText(string prompt, string systemPrompt, TextBlock textBlock, LanguageModelOptionsExperimental? options = null)
+    public async Task GenerateText(string prompt, string systemPrompt, TextBlock textBlock, LanguageModelOptions? options = null)
     {
-        if (_languageModel == null || _loraModel == null)
+        if (_languageModel == null)
         {
             ShowException(null, "Phi-Silica is not available.");
             return;
@@ -176,8 +173,8 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
         //  it is created for each query to avoid bringing history from previous queries
         LanguageModelContext? context = systemPrompt.Length > 0 ? _languageModel.CreateContext(systemPrompt) : null;
         operation = context == null ?
-            options == null ? _languageModel.GenerateResponseAsync(prompt) : _loraModel.GenerateResponseAsync(prompt, options) :
-            options == null ? _languageModel.GenerateResponseAsync(context, prompt, new LanguageModelOptions()) : _loraModel.GenerateResponseAsync(context, prompt, options);
+            options == null ? _languageModel.GenerateResponseAsync(prompt) : _languageModel.GenerateResponseAsync(prompt, options) :
+            options == null ? _languageModel.GenerateResponseAsync(context, prompt, new LanguageModelOptions()) : _languageModel.GenerateResponseAsync(context, prompt, options);
 
         if (operation == null)
         {
@@ -216,18 +213,24 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
         NarratorHelper.Announce(InputTextBox, "Content has finished generating.", "GenerateDoneAnnouncementActivityId"); // <exclude-line>
     }
 
-    private LanguageModelOptionsExperimental? LoadAdapter()
+    private LanguageModelOptions? LoadAdapter()
     {
-        if (_loraModel == null)
+        if (_languageModel == null)
         {
             ShowException(null, "Phi-Silica is not available.");
             return null;
         }
 
-        LowRankAdaptation? loraAdapter;
+        LanguageModelLowRankAdapter? loraAdapter;
         try
         {
-            loraAdapter = _loraModel.LoadAdapter(_adapterFilePath);
+            var adapterResult = LanguageModelLowRankAdapter.CreateFromPath(_adapterFilePath);
+            loraAdapter = adapterResult.LowRankAdapter;
+            if (loraAdapter == null)
+            {
+                ShowException(null, $"Could not create LanguageModelLowRankAdapter: {adapterResult.ExtendedError}");
+                return null;
+            }
         }
         catch (Exception ex)
         {
@@ -235,9 +238,9 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
             return null;
         }
 
-        var options = new LanguageModelOptionsExperimental
+        var options = new LanguageModelOptions
         {
-            LoraAdapter = loraAdapter
+            LowRankAdapter = loraAdapter
         };
         return options;
     }
@@ -256,7 +259,7 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
             return;
         }
 
-        if (this.InputTextBox.Text.Length > 0 && _loraModel != null)
+        if (this.InputTextBox.Text.Length > 0)
         {
             GenerateButton.Visibility = Visibility.Collapsed;
             StopBtn.Visibility = Visibility.Visible;
@@ -266,7 +269,7 @@ internal sealed partial class PhiSilicaLoRa : BaseSamplePage
 
             _cts?.Cancel();
             _cts = new CancellationTokenSource();
-            var options = new LanguageModelOptionsExperimental();
+            LanguageModelOptions? options = null;
             try
             {
                 switch (_generationType)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Media" Version="8.2.250402" />
     <PackageVersion Include="Microsoft.AI.Foundry.Local.WinML" Version="0.8.2.1" />
     <PackageVersion Include="Microsoft.Extensions.AI" Version="10.2.0" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="2.0.325-experimental" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK.ML" Version="2.1.3-experimental" />
     <PackageVersion Include="OllamaSharp" Version="5.4.7" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.2.0-preview.1.26063.2" />
     <PackageVersion Include="Microsoft.SemanticKernel.Connectors.InMemory" Version="1.72.0-preview" />
@@ -31,7 +31,7 @@
     <PackageVersion Include="CommunityToolkit.WinUI.Extensions" Version="8.2.250402" />
     <PackageVersion Include="CommunityToolkit.WinUI.Controls.Sizers" Version="8.2.250402" />
     <PackageVersion Include="Microsoft.Graphics.Win2D" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.0.0-experimental7" />
+    <PackageVersion Include="Microsoft.WindowsAppSDK" Version="2.1.4-experimental8" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.6584" />
     <PackageVersion Include="Microsoft.Windows.SDK.BuildTools.MSIX" Version="1.7.251221100" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />


### PR DESCRIPTION
- Eable VSR on CPU through the WindowsAppSDK upgrade (no code change needed in the VSR sample)
- Bump Microsoft.WindowsAppSDK 2.0.0-experimental7 -> 2.1.4-experimental8
- Align Microsoft.WindowsAppSDK.ML entry to 2.1.3-experimental
- Migrate PhiSilica LoRA sample to the promoted LanguageModelLowRankAdapter API