### PR TITLE
SFI: enable C# CodeQL coverage

### DIFF
--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -38,6 +38,11 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-latest
         os: windows
+      codeql:
+        compiled:
+          enabled: true
+        buildIdentifier: 'Build_$(System.JobAttempt)'
+        runSourceLanguagesInSourceAnalysis: true
     stages:
     - stage: Build
       jobs:

--- a/.pipelines/ci.yml
+++ b/.pipelines/ci.yml
@@ -40,7 +40,7 @@ extends:
         os: windows
       codeql:
         compiled:
-          enabled: true
+          enabled: false
         buildIdentifier: 'Build_$(System.JobAttempt)'
         runSourceLanguagesInSourceAnalysis: true
     stages:

--- a/.pipelines/release.yml
+++ b/.pipelines/release.yml
@@ -32,6 +32,11 @@ extends:
         name: Azure-Pipelines-1ESPT-ExDShared
         image: windows-latest
         os: windows
+      codeql:
+        compiled:
+          enabled: false
+        buildIdentifier: 'Build_$(System.JobAttempt)'
+        runSourceLanguagesInSourceAnalysis: true
     stages:
     - stage: Build
       jobs:

--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -23,6 +23,7 @@ steps:
   displayName: Build - ${{ parameters.dotnet_platform }}
 - task: CodeQL3000Finalize@0
   displayName: 'CodeQL Finalize'
+  condition: always()
 - ${{ if eq(parameters.publishSymbols, true) }}:
   - task: PublishSymbols@2
     displayName: Publish Symbols - ${{ parameters.dotnet_platform }}

--- a/.pipelines/templates/build.yaml
+++ b/.pipelines/templates/build.yaml
@@ -15,10 +15,14 @@ steps:
   displayName: Update Package Manifest Version
 - script: dotnet restore AIDevGallery.sln -r win-${{ parameters.dotnet_platform }} /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:PublishReadyToRun=true /p:SelfContainedIfPreviewWASDK=true
   displayName: Restore dependencies - ${{ parameters.dotnet_platform }}
+- task: CodeQL3000Init@0
+  displayName: 'CodeQL Initialize'
 - script: |
     dotnet build AIDevGallery.Utils --no-restore /p:Configuration=Release
     dotnet build AIDevGallery --no-restore -r win-${{ parameters.dotnet_platform }} -f net9.0-windows10.0.26100.0 /p:Configuration=${{ parameters.dotnet_configuration }} /p:Platform=${{ parameters.dotnet_platform }} /p:AppxPackageDir="AppPackages/" /p:UapAppxPackageBuildMode=SideloadOnly /p:AppxBundle=Never /p:GenerateAppxPackageOnBuild=true /p:SelfContainedIfPreviewWASDK=true /p:LafPublisherId=$(LAF_PUBLISHER_ID) /p:LafToken=$(LAF_TOKEN)
   displayName: Build - ${{ parameters.dotnet_platform }}
+- task: CodeQL3000Finalize@0
+  displayName: 'CodeQL Finalize'
 - ${{ if eq(parameters.publishSymbols, true) }}:
   - task: PublishSymbols@2
     displayName: Publish Symbols - ${{ parameters.dotnet_platform }}

--- a/AIDevGallery/AIDevGallery.csproj
+++ b/AIDevGallery/AIDevGallery.csproj
@@ -20,6 +20,7 @@
     <!-- TODO: Fix IDisposableAnalyzers warnings from Microsoft.AI.Foundry.Local.WinML transitive dependency in next PR -->
     <NoWarn>$(NoWarn);IDISP001;IDISP002;IDISP003;IDISP004;IDISP006;IDISP007;IDISP008;IDISP017;IDISP025</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
+    <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <TrimmerRootDescriptor>SamplesRoots.xml</TrimmerRootDescriptor>
     <!-- The *first* DefineConstants is removed during Official Release Builds (.pipelines/Unstub.ps1)-->
     <DefineConstants>TELEMETRYEVENTSOURCE_PUBLIC</DefineConstants>

--- a/AIDevGallery/AIDevGallery.csproj
+++ b/AIDevGallery/AIDevGallery.csproj
@@ -20,6 +20,7 @@
     <!-- TODO: Fix IDisposableAnalyzers warnings from Microsoft.AI.Foundry.Local.WinML transitive dependency in next PR -->
     <NoWarn>$(NoWarn);IDISP001;IDISP002;IDISP003;IDISP004;IDISP006;IDISP007;IDISP008;IDISP017;IDISP025</NoWarn>
     <IsAotCompatible>true</IsAotCompatible>
+    <!-- Pinned via TreatAsLocalProperty on <Project> so the CodeQL tracer can't override it; enabling it causes CS0016 build failures with WinRTAotSourceGenerator. -->
     <EmitCompilerGeneratedFiles>false</EmitCompilerGeneratedFiles>
     <TrimmerRootDescriptor>SamplesRoots.xml</TrimmerRootDescriptor>
     <!-- The *first* DefineConstants is removed during Official Release Builds (.pipelines/Unstub.ps1)-->

--- a/AIDevGallery/AIDevGallery.csproj
+++ b/AIDevGallery/AIDevGallery.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk" TreatAsLocalProperty="EmitCompilerGeneratedFiles">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net9.0-windows10.0.26100.0</TargetFramework>


### PR DESCRIPTION
## Summary

Restore C# CodeQL coverage for `microsoft/ai-dev-gallery` to clear the related SFI item.

CodeQL3000 had been silently failing to produce a C# database. After merge, CI run produces and uploads a fresh C# CodeQL database via 1ES PT, replacing the previously-broken external CCA autobuilder path.

## Fix

- **`.pipelines/templates/build.yaml`** — Wrap the build step with explicit `CodeQL3000Init@0` / `CodeQL3000Finalize@0` so the tracer actually attaches to our `script: dotnet build` (auto-injector ignores bare scripts).
- **`.pipelines/ci.yml`** — Add `sdl.codeql` block: enable CodeQL, set `compiled.enabled: false` (avoid duplicating our explicit pair), and set `buildIdentifier: 'Build_$(System.JobAttempt)'` to keep cadence keys distinct across retries.
- **`.pipelines/release.yml`** — Mirror the same `sdl.codeql` block. Also resolves the long-standing release attempt-1 CS0016 failure caused by tracer injection on the Official template.
## Verification

End-to-end validation on a verify branch:

- Build succeeded cleanly on the first attempt — no CS0016, no WMC9999.
- CodeQL Finalize uploaded the C# database
- Portal shows the row: branch `codeql-verify`, Language **C#**, BuildSource `CodeQL3000_1ESPT`.

