### PR TITLE
A11y: Fix model picker Names, unique accelerator labels, and code sample Name length

### DIFF
--- a/AIDevGallery/Controls/Markdown/TextElements/MyList.cs
+++ b/AIDevGallery/Controls/Markdown/TextElements/MyList.cs
@@ -3,6 +3,8 @@
 
 using Markdig.Syntax;
 using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
 using RomanNumerals;
@@ -85,6 +87,8 @@ internal class MyList : IAddChild
         textBlock.SetValue(Grid.ColumnProperty, 0);
         textBlock.VerticalAlignment = VerticalAlignment.Top;
         textBlock.TextAlignment = TextAlignment.Right;
+
+        AutomationProperties.SetAccessibilityView(textBlock, AccessibilityView.Raw);
         grid.Children.Add(textBlock);
         var flowDoc = new MyFlowDocument();
         flowDoc.AddChild(child);
@@ -92,6 +96,8 @@ internal class MyList : IAddChild
         flowDoc.RichTextBlock.SetValue(Grid.ColumnProperty, 2);
         flowDoc.RichTextBlock.Padding = new Thickness(0);
         flowDoc.RichTextBlock.VerticalAlignment = VerticalAlignment.Top;
+
+        AutomationProperties.SetAccessibilityView(flowDoc.RichTextBlock, AccessibilityView.Raw);
         grid.Children.Add(flowDoc.RichTextBlock);
 
         _stackPanel.Children.Add(grid);

--- a/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/AddHFModelView.xaml
@@ -191,7 +191,7 @@
                                         <DataTemplate x:DataType="models:HardwareAccelerator">
                                             <Button
                                                 VerticalAlignment="Center"
-                                                AutomationProperties.Name="More info"
+                                                AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                 Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                 Style="{StaticResource TertiaryButtonStyle}"
                                                 ToolTipService.ToolTip="More info">

--- a/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
@@ -202,6 +202,7 @@
                     Width="120"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Stretch"
+                    AutomationProperties.Name="Run sample"
                     Click="OnSave_Clicked"
                     Style="{StaticResource AccentButtonStyle}">
                     <StackPanel Orientation="Vertical" Spacing="4">

--- a/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
@@ -173,7 +173,7 @@
                                                 <DataTemplate x:DataType="models:HardwareAccelerator">
                                                     <Button
                                                         VerticalAlignment="Center"
-                                                        AutomationProperties.Name="More info"
+                                                        AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                         Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                         Style="{StaticResource TertiaryButtonStyle}"
                                                         ToolTipService.ToolTip="More info"

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
@@ -148,7 +148,7 @@
                                                     <DataTemplate x:DataType="models:HardwareAccelerator">
                                                         <Button
                                                             VerticalAlignment="Center"
-                                                            AutomationProperties.Name="More info"
+                                                            AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                             Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                             Style="{StaticResource TertiaryButtonStyle}"
                                                             Tapped="StopPropagatingHandler"
@@ -323,7 +323,7 @@
                                                 <DataTemplate x:DataType="models:HardwareAccelerator">
                                                     <Button
                                                         VerticalAlignment="Center"
-                                                        AutomationProperties.Name="More info"
+                                                        AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                         Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                         Style="{StaticResource TertiaryButtonStyle}"
                                                         ToolTipService.ToolTip="More info"

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
@@ -44,6 +44,7 @@
                         <controls:WrapPanel Orientation="Horizontal" ItemSpacing="12" LineSpacing="12">
                             <Button
                             x:Name="OpenAIToolkitButton"
+                            AutomationProperties.Name="Open AI Toolkit's Conversion tool"
                             Click="OpenAIToolkitButton_Click"
                             Visibility="Visible">
                                 <StackPanel Orientation="Horizontal">
@@ -60,6 +61,7 @@
                             </Button>
                             <Button
                             x:Name="ViewDocumentationButton"
+                            AutomationProperties.Name="View documentation"
                             Click="ViewDocumentationButton_Click"
                             Visibility="Visible">
                                 <StackPanel Orientation="Horizontal">
@@ -243,6 +245,7 @@
                         Grid.Column="1"
                         Padding="0"
                         Visibility="Collapsed"
+                        AutomationProperties.Name="Add model"
                         Background="Transparent"
                         BorderThickness="0"
                         Foreground="{ThemeResource AccentTextFillColorPrimaryBrush}">

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/OnnxPickerView.xaml
@@ -56,7 +56,7 @@
                                         UriSource="ms-appx:///Assets/AITKIcon.png" />
                                         </Image.Source>
                                     </Image>
-                                    <TextBlock Text="Open AI Toolkit`s Conversion tool" Margin="5,0,0,0" />
+                                    <TextBlock Text="Open AI Toolkit's Conversion tool" Margin="5,0,0,0" />
                                 </StackPanel>
                             </Button>
                             <Button

--- a/AIDevGallery/Controls/ModelSelectionControl.xaml
+++ b/AIDevGallery/Controls/ModelSelectionControl.xaml
@@ -81,7 +81,7 @@
                                                     <DataTemplate x:DataType="models:HardwareAccelerator">
                                                         <Button
                                                             VerticalAlignment="Center"
-                                                            AutomationProperties.Name="More info"
+                                                            AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                             Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                             Style="{StaticResource TertiaryButtonStyle}"
                                                             Tapped="StopPropagatingHandler"
@@ -296,7 +296,7 @@
                                                 <DataTemplate x:DataType="models:HardwareAccelerator">
                                                     <Button
                                                         VerticalAlignment="Center"
-                                                        AutomationProperties.Name="More info"
+                                                        AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                         Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                         Style="{StaticResource TertiaryButtonStyle}"
                                                         ToolTipService.ToolTip="More info">
@@ -468,7 +468,7 @@
                                                 <DataTemplate x:DataType="models:HardwareAccelerator">
                                                     <Button
                                                         VerticalAlignment="Center"
-                                                        AutomationProperties.Name="More info"
+                                                        AutomationProperties.Name="{x:Bind utils:AppUtils.GetHardwareAcceleratorMoreInfoName((models:HardwareAccelerator))}"
                                                         Content="{x:Bind utils:AppUtils.GetHardwareAcceleratorString((models:HardwareAccelerator))}"
                                                         Style="{StaticResource TertiaryButtonStyle}"
                                                         ToolTipService.ToolTip="More info">

--- a/AIDevGallery/Pages/APIs/APIPage.xaml
+++ b/AIDevGallery/Pages/APIs/APIPage.xaml
@@ -184,6 +184,7 @@
                         Grid.Row="1"
                         Margin="0"
                         Padding="0"
+                        AutomationProperties.Name="API code sample"
                         Background="Transparent"
                         HorizontalScrollBarVisibility="Visible"
                         HorizontalScrollMode="Auto"

--- a/AIDevGallery/Utils/AppUtils.cs
+++ b/AIDevGallery/Utils/AppUtils.cs
@@ -184,6 +184,11 @@ internal static class AppUtils
         }
     }
 
+    public static string GetHardwareAcceleratorMoreInfoName(HardwareAccelerator hardwareAccelerator)
+    {
+        return $"{GetHardwareAcceleratorString(hardwareAccelerator)} more info";
+    }
+
     public static string GetHardwareAcceleratorDescription(HardwareAccelerator hardwareAccelerator)
     {
         if (ExternalModelHelper.HardwareAccelerators.Contains(hardwareAccelerator))


### PR DESCRIPTION
Fixes for accessibility bugs reported against AI Dev Gallery. Each fix is in its own commit for independent review.

## Fixes
- **Model picker buttons**: Panel-content buttons (Run sample, Add model, Open AI Toolkit, View documentation) now expose a UIA Name instead of null.
- **Hardware accelerator badges**: CPU/GPU/NPU "More info" buttons now have unique Names (e.g. "GPU more info") so focusable siblings aren't identical.
- **Markdown lists**: Decorative list-item wrappers and bullet glyphs are excluded from the accessibility tree to avoid whitespace-only Names.
- **API code sample**: The code RichTextBlock/ScrollViewer now exposes a concise Name instead of the full source (was exceeding 512 characters).

## Validation
Verified manually with Accessibility Insights for Windows on the reported pages; project builds clean for x64.