### PR TITLE
A11y: Fix code-pane focus order, focus visibility, tooltips, and View code button

### DIFF
--- a/AIDevGallery/Controls/Card.xaml
+++ b/AIDevGallery/Controls/Card.xaml
@@ -78,9 +78,19 @@
             HorizontalAlignment="Stretch"
             VerticalAlignment="Stretch"
             Click="Button_Click"
-            Content="View code"
             Style="{StaticResource FadedButtonStyle}"
-            Visibility="Collapsed" />
+            Visibility="Collapsed">
+            <Border
+                Padding="12,4,12,4"
+                Background="{ThemeResource ControlFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource ControlElevationBorderBrush}"
+                BorderThickness="1"
+                CornerRadius="{StaticResource ControlCornerRadius}">
+                <TextBlock
+                    Foreground="{ThemeResource TextFillColorPrimaryBrush}"
+                    Text="View code" />
+            </Border>
+        </Button>
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="IconVisibilityStates">
                 <VisualState x:Name="IconVisible" />

--- a/AIDevGallery/Controls/SampleContainer.xaml
+++ b/AIDevGallery/Controls/SampleContainer.xaml
@@ -154,6 +154,7 @@
                         x:Name="CodeTabView"
                         Margin="0,8,0,0"
                         IsAddTabButtonVisible="False"
+                        PreviewKeyDown="CodeTabView_PreviewKeyDown"
                         SelectionChanged="CodeTabView_SelectionChanged"
                         TabWidthMode="SizeToContent" />
                     <Grid Grid.Row="1" Background="{ThemeResource SolidBackgroundFillColorTertiaryBrush}">
@@ -187,6 +188,7 @@
                             <Border 
                                 IsTabStop="True" 
                                 Background="Transparent" 
+                                UseSystemFocusVisuals="True"
                                 x:Name="RichTextBlockBorder">
                                 <RichTextBlock
                                     x:Name="CodeTextBlock"

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -11,6 +11,7 @@ using ColorCode;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
 using Microsoft.Windows.AI;
 using System;
 using System.Collections.Generic;
@@ -59,6 +60,8 @@ internal sealed partial class SampleContainer : UserControl
     public static readonly DependencyProperty NugetPackageReferencesProperty =
         DependencyProperty.Register("NugetPackageReferences", typeof(List<string>), typeof(SampleContainer), new PropertyMetadata(null));
 
+    public event EventHandler? CodePaneFocusReturnRequested;
+
     private RichTextBlockFormatter codeFormatter;
     private Dictionary<string, string> codeFiles = new();
     private Sample? _sampleCache;
@@ -69,6 +72,7 @@ internal sealed partial class SampleContainer : UserControl
     private TaskCompletionSource? _sampleLoadedCompletionSource;
     private double _codePaneWidth;
     private ModelType? _wcrApi;
+    private bool _pendingFocusCodeTabOnShow;
 
     private static readonly List<WeakReference<SampleContainer>> References = [];
 
@@ -461,10 +465,84 @@ internal sealed partial class SampleContainer : UserControl
 
     public void ShowCode()
     {
+        _pendingFocusCodeTabOnShow = true;
+
         RenderCodeTabs();
 
         CodeColumn.Width = _codePaneWidth == 0 ? new GridLength(1, GridUnitType.Star) : new GridLength(_codePaneWidth);
         VisualStateManager.GoToState(this, "ShowCodePane", true);
+
+        FocusSelectedCodeTab();
+    }
+
+    private void FocusSelectedCodeTab()
+    {
+        if (!_pendingFocusCodeTabOnShow || CodeTabView.SelectedItem is not TabViewItem selectedTab)
+        {
+            return;
+        }
+
+        if (TryFocusTab(selectedTab))
+        {
+            _pendingFocusCodeTabOnShow = false;
+            return;
+        }
+
+        void OnLayoutUpdated(object? sender, object e)
+        {
+            if (!_pendingFocusCodeTabOnShow || TryFocusTab(selectedTab))
+            {
+                _pendingFocusCodeTabOnShow = false;
+                CodeTabView.LayoutUpdated -= OnLayoutUpdated;
+            }
+        }
+
+        CodeTabView.LayoutUpdated += OnLayoutUpdated;
+    }
+
+    private bool TryFocusTab(TabViewItem tab)
+    {
+        if (!tab.IsLoaded)
+        {
+            return false;
+        }
+
+        // Keyboard focus state so the focus rectangle is visible.
+        tab.Focus(FocusState.Keyboard);
+        return ReferenceEquals(FocusManager.GetFocusedElement(XamlRoot), tab);
+    }
+
+    /// <summary>
+    /// Moves keyboard focus onto the open code pane's selected tab. Bridges the
+    /// gap between the Code toggle button and the pane, which are far apart in
+    /// the XAML tree.
+    /// </summary>
+    /// <returns><c>true</c> if focus was moved into the pane.</returns>
+    public bool FocusCodePane()
+    {
+        if (CodeGrid.Visibility != Visibility.Visible || CodeTabView.SelectedItem is not TabViewItem selectedTab)
+        {
+            return false;
+        }
+
+        return TryFocusTab(selectedTab);
+    }
+
+    private void CodeTabView_PreviewKeyDown(object sender, KeyRoutedEventArgs e)
+    {
+        if (e.Key != Windows.System.VirtualKey.Tab)
+        {
+            return;
+        }
+
+        var shiftState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift);
+        bool isShiftDown = shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+
+        if (isShiftDown && FocusManager.GetFocusedElement(XamlRoot) is TabViewItem)
+        {
+            CodePaneFocusReturnRequested?.Invoke(this, EventArgs.Empty);
+            e.Handled = true;
+        }
     }
 
     public void HideCode()
@@ -548,7 +626,15 @@ internal sealed partial class SampleContainer : UserControl
 
         LineNumbersTextBlock.Text = lineNumbers.ToString();
         Microsoft.UI.Xaml.Automation.AutomationProperties.SetName(CodeTextBlock, $"{codeName} code");
-        RichTextBlockBorder.Focus(FocusState.Programmatic);
+
+        if (_pendingFocusCodeTabOnShow)
+        {
+            FocusSelectedCodeTab();
+        }
+        else
+        {
+            RichTextBlockBorder.Focus(FocusState.Programmatic);
+        }
     }
 
     private void ScrollViewer_ViewChanging(object sender, ScrollViewerViewChangingEventArgs e)

--- a/AIDevGallery/Pages/Models/ModelPage.xaml
+++ b/AIDevGallery/Pages/Models/ModelPage.xaml
@@ -122,7 +122,7 @@
                             VerticalScrollBarVisibility="Auto"
                             Grid.Row="2"
                             Margin="-16"
-                            Padding="20,12,20,0">
+                            Padding="20,12,20,12">
                             <toolkit2:MarkdownTextBlock
                                 IsTabStop="False"
                                 x:Name="markdownTextBlock"

--- a/AIDevGallery/Pages/Models/ModelPage.xaml
+++ b/AIDevGallery/Pages/Models/ModelPage.xaml
@@ -174,7 +174,8 @@
                                 <ItemContainer
                                     HorizontalAlignment="Left"
                                     AutomationProperties.Name="{x:Bind Name}"
-                                    CornerRadius="16">
+                                    CornerRadius="16"
+                                    ToolTipService.ToolTip="{x:Bind Name}">
                                     <Grid
                                         Padding="12,6,12,6"
                                         Background="{ThemeResource CardBackgroundFillColorSecondaryBrush}"

--- a/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml
+++ b/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml
@@ -375,6 +375,7 @@
                         Background="Transparent"
                         BorderThickness="0"
                         Click="CodeToggle_Click"
+                        PreviewKeyDown="CodeToggle_PreviewKeyDown"
                         ToolTipService.ToolTip="Show source code">
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <Viewbox Width="16" Margin="0,-2,0,0">

--- a/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
@@ -51,6 +51,28 @@ internal sealed partial class ScenarioPage : Page
         BackgroundShadow.Receivers.Add(ShadowCastGrid);
         App.MainWindow.ModelPicker.SelectedModelsChanged += ModelOrApiPicker_SelectedModelsChanged;
         this.Unloaded += (s, e) => App.MainWindow.ModelPicker.SelectedModelsChanged -= ModelOrApiPicker_SelectedModelsChanged;
+        SampleContainer.CodePaneFocusReturnRequested += SampleContainer_CodePaneFocusReturnRequested;
+    }
+
+    private void SampleContainer_CodePaneFocusReturnRequested(object? sender, EventArgs e)
+    {
+        CodeToggle.Focus(FocusState.Programmatic);
+    }
+
+    private void CodeToggle_PreviewKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (e.Key != Windows.System.VirtualKey.Tab || CodeToggle.IsChecked != true)
+        {
+            return;
+        }
+
+        var shiftState = Microsoft.UI.Input.InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Shift);
+        bool isShiftDown = shiftState.HasFlag(Windows.UI.Core.CoreVirtualKeyStates.Down);
+
+        if (!isShiftDown && SampleContainer.FocusCodePane())
+        {
+            e.Handled = true;
+        }
     }
 
     protected override void OnNavigatedTo(NavigationEventArgs e)

--- a/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
+++ b/AIDevGallery/Pages/Scenarios/ScenarioPage.xaml.cs
@@ -56,7 +56,8 @@ internal sealed partial class ScenarioPage : Page
 
     private void SampleContainer_CodePaneFocusReturnRequested(object? sender, EventArgs e)
     {
-        CodeToggle.Focus(FocusState.Programmatic);
+        // Keyboard focus state so the focus rectangle is visible after Shift+Tab.
+        CodeToggle.Focus(FocusState.Keyboard);
     }
 
     private void CodeToggle_PreviewKeyDown(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)

--- a/AIDevGallery/Samples/Open Source Models/Language Models/ExplainCode.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/ExplainCode.xaml
@@ -68,7 +68,7 @@
             Grid.Row="3"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/Open Source Models/Language Models/GenerateCode.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/GenerateCode.xaml
@@ -78,7 +78,7 @@
         <ScrollViewer
             Grid.Row="4"
             AutomationProperties.Name="Generated Text Scroll Area"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once">
             <RichTextBlock
                 x:Name="GenerateRichTextBlock"

--- a/AIDevGallery/Samples/Open Source Models/Language Models/GrammarCheck.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/GrammarCheck.xaml
@@ -68,7 +68,7 @@
             Grid.Row="3"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Paraphrase.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Paraphrase.xaml
@@ -67,7 +67,7 @@
             Grid.Row="3"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/Open Source Models/Language Models/SentimentAnalysis.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/SentimentAnalysis.xaml
@@ -67,7 +67,7 @@
             Grid.Row="3"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/Open Source Models/Language Models/Translate.xaml
+++ b/AIDevGallery/Samples/Open Source Models/Language Models/Translate.xaml
@@ -77,7 +77,7 @@
             Grid.Row="4"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/WCRAPIs/DescribeYourChange.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/DescribeYourChange.xaml
@@ -114,7 +114,7 @@
             Grid.Row="4"
             AutomationProperties.Name="Rewritten Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/WCRAPIs/PhiSilicaBasic.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/PhiSilicaBasic.xaml
@@ -64,7 +64,7 @@
             Grid.ColumnSpan="2"
             AutomationProperties.Name="Generated Text Scroll Area"
             HorizontalScrollBarVisibility="Disabled"
-            IsTabStop="True"
+            IsTabStop="False"
             TabNavigation="Once"
             VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/WCRAPIs/TextRewrite.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/TextRewrite.xaml
@@ -67,7 +67,7 @@
         Grid.Row="3"
         AutomationProperties.Name="Rewritten Text Scroll Area"
         HorizontalScrollBarVisibility="Disabled"
-        IsTabStop="True"
+        IsTabStop="False"
         TabNavigation="Once"
         VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/WCRAPIs/TextSummarize.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/TextSummarize.xaml
@@ -67,7 +67,7 @@
         Grid.Row="3"
         AutomationProperties.Name="Summarized Text Scroll Area"
         HorizontalScrollBarVisibility="Disabled"
-        IsTabStop="True"
+        IsTabStop="False"
         TabNavigation="Once"
         VerticalScrollBarVisibility="Auto">
             <TextBlock

--- a/AIDevGallery/Samples/WCRAPIs/TextToTable.xaml
+++ b/AIDevGallery/Samples/WCRAPIs/TextToTable.xaml
@@ -67,7 +67,7 @@
         Grid.Row="3"
         AutomationProperties.Name="Converted Table Scroll Area"
         HorizontalScrollBarVisibility="Disabled"
-        IsTabStop="True"
+        IsTabStop="False"
         TabNavigation="Once"
         VerticalScrollBarVisibility="Auto">
             <StackPanel>


### PR DESCRIPTION
Fixes for accessibility bugs against AI Dev Gallery. Each fix is in its own commit for independent review.

## Fixes
- **Code pane focus navigation** (samples): Tab from the Code button now moves focus into the code pane (selected tab), and Shift+Tab from the pane returns focus to the Code button, instead of skipping far across the XAML tree.
- **Focused link visibility** (model page): Added bottom padding so the focus rectangle on the last documentation link is fully visible instead of being clipped by the card edge.
- **Suggested sample tooltips** (model page): Sample chips whose names are truncated now show a tooltip with the full name on hover/focus.
- **Empty output focus** (samples): Output scroll areas no longer take keyboard focus when empty, so Tab moves to the next interactive control. Applied consistently across 11 samples to match those already working correctly.
- **View code button**: Restyled the "View code" affordance with a bordered pill so it's clearly distinguishable from normal text.

## Validation
Verified manually with keyboard navigation and Accessibility Insights for Windows on the reported page.