### PR TITLE
Validate HuggingFace URL prefix correctly in HuggingFaceUrl constructor

### DIFF
--- a/AIDevGallery.Tests/UnitTests/Utils/ModelUrlTests.cs
+++ b/AIDevGallery.Tests/UnitTests/Utils/ModelUrlTests.cs
@@ -241,6 +241,27 @@ public class HuggingFaceUrlTests
     }
 
     [TestMethod]
+    public void ConstructorWithBaseUrlOnlyShouldThrowArgumentException()
+    {
+        // Arrange - the base URL with no repo path must be rejected with
+        // ArgumentException, not crash with ArgumentOutOfRangeException.
+        var url = "https://huggingface.co";
+
+        // Act & Assert
+        Assert.ThrowsExactly<System.ArgumentException>(() => new HuggingFaceUrl(url));
+    }
+
+    [TestMethod]
+    public void ConstructorWithLookalikeDomainShouldThrowException()
+    {
+        // Arrange - a host that merely starts with the base host must not be accepted.
+        var url = "https://huggingface.competitor.com/evil/repo";
+
+        // Act & Assert
+        Assert.ThrowsExactly<System.ArgumentException>(() => new HuggingFaceUrl(url));
+    }
+
+    [TestMethod]
     public void ConstructorWithUrlHavingWhitespaceShouldTrimAndParse()
     {
         // Arrange

--- a/AIDevGallery.Utils/ModelUrl.cs
+++ b/AIDevGallery.Utils/ModelUrl.cs
@@ -126,12 +126,12 @@ public class HuggingFaceUrl : ModelUrl
 
         if (modelNameOrUrl.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
         {
-            if (!modelNameOrUrl.StartsWith(BaseUrl, StringComparison.OrdinalIgnoreCase))
+            if (!modelNameOrUrl.StartsWith($"{BaseUrl}/", StringComparison.OrdinalIgnoreCase))
             {
                 throw new ArgumentException("Invalid URL", nameof(modelNameOrUrl));
             }
 
-            modelNameOrUrl = modelNameOrUrl[23..];
+            modelNameOrUrl = modelNameOrUrl[(BaseUrl.Length + 1)..];
         }
 
         string[] urlComponents = modelNameOrUrl.Split(['/'], StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
## Problem

`HuggingFaceUrl`'s constructor checks the base-URL prefix without the trailing slash, then strips a hardcoded 23 characters:

```csharp
if (!modelNameOrUrl.StartsWith(BaseUrl, StringComparison.OrdinalIgnoreCase))   // BaseUrl = "https://huggingface.co" (22 chars)
{
    throw new ArgumentException("Invalid URL", nameof(modelNameOrUrl));
}
modelNameOrUrl = modelNameOrUrl[23..];
```

Two concrete, deterministic failures result:

1. The exact base URL `"https://huggingface.co"` (22 chars) passes the loose check, then `[23..]` indexes past the end → **`ArgumentOutOfRangeException`** instead of the `ArgumentException("Invalid URL")` thrown by every other invalid-input path.
2. A lookalike host `"https://huggingface.competitor.com/evil/repo"` passes the loose `StartsWith` check, then `[23..]` slices mid-domain → silently mis-parses to `Organization = "petitor.com"` instead of being rejected.

The sibling `GitHubUrl` constructor already does this correctly (`StartsWith($"{BaseUrl}/")` and `url[(BaseUrl.Length + 1)..]`).

## Reproduction (real ModelUrl.cs in a console harness)

```
before:  new HuggingFaceUrl("https://huggingface.co")                              => THROW ArgumentOutOfRangeException
before:  new HuggingFaceUrl("https://huggingface.competitor.com/evil/repo")        => Org=petitor.com Repo=evil
after:   new HuggingFaceUrl("https://huggingface.co")                              => THROW ArgumentException
after:   new HuggingFaceUrl("https://huggingface.competitor.com/evil/repo")        => THROW ArgumentException
```
Valid inputs (`https://huggingface.co/org/repo`, `org/repo`) are unchanged.

## Fix

Require the trailing slash and strip `BaseUrl.Length + 1`, mirroring `GitHubUrl`:

```csharp
if (!modelNameOrUrl.StartsWith($"{BaseUrl}/", StringComparison.OrdinalIgnoreCase)) { ... }
modelNameOrUrl = modelNameOrUrl[(BaseUrl.Length + 1)..];
```

## Test

Adds `ConstructorWithBaseUrlOnlyShouldThrowArgumentException` and `ConstructorWithLookalikeDomainShouldThrowException` to `ModelUrlTests.cs` (both `Assert.ThrowsExactly<ArgumentException>`).