### PR TITLE
feat: make Windows AI API hardware requirement message dynamic per API

### DIFF
--- a/AIDevGallery.SourceGenerator/Models/ApiDefinition.cs
+++ b/AIDevGallery.SourceGenerator/Models/ApiDefinition.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace AIDevGallery.SourceGenerator.Models;
 
 internal class ApiDefinition
@@ -14,4 +16,9 @@ internal class ApiDefinition
     public required string License { get; init; }
     public required string SampleIdToShowInDocs { get; init; }
     public string? Category { get; init; } = null;
+
+    public List<HardwareAccelerator>? SupportedHardwareAccelerators { get; init; } = null;
+
+    // Optional. The API's own "supported hardware" documentation page.
+    public string? SupportedHardwareUrl { get; init; } = null;
 }

--- a/AIDevGallery.SourceGenerator/ModelsSourceGenerator.cs
+++ b/AIDevGallery.SourceGenerator/ModelsSourceGenerator.cs
@@ -337,6 +337,8 @@ internal class ModelSourceGenerator : IIncrementalGenerator
                                 License = "{{apiDefinition.License}}"
                                 {{(!string.IsNullOrWhiteSpace(apiDefinition.SampleIdToShowInDocs) ? $",SampleIdToShowInDocs = \"{apiDefinition.SampleIdToShowInDocs}\"" : string.Empty)}}
                                 {{(!string.IsNullOrWhiteSpace(apiDefinition.Category) ? $",Category = \"{apiDefinition.Category}\"" : string.Empty)}}
+                                {{(apiDefinition.SupportedHardwareAccelerators is { Count: > 0 } accelerators ? $",SupportedHardwareAccelerators = [ {string.Join(", ", accelerators.Select(a => $"HardwareAccelerator.{a}"))} ]" : string.Empty)}}
+                                {{(!string.IsNullOrWhiteSpace(apiDefinition.SupportedHardwareUrl) ? $",SupportedHardwareUrl = \"{apiDefinition.SupportedHardwareUrl}\"" : string.Empty)}}
                             }
                         },
                 """");

--- a/AIDevGallery.Tests/UnitTests/WcrApiConfigurationTests.cs
+++ b/AIDevGallery.Tests/UnitTests/WcrApiConfigurationTests.cs
@@ -188,4 +188,56 @@ public class WcrApiConfigurationTests
                 $"GetStringDescription should return a non-empty message for {modelType} when NotSupportedOnCurrentSystem");
         }
     }
+
+    [TestMethod]
+    public void GetHardwareRequirementInfoLanguageModelBackedMentionsGpu()
+    {
+        foreach (var modelType in GetLanguageModelBacked())
+        {
+            var (requirement, _) = WcrApiHelpers.GetHardwareRequirementInfo(modelType);
+
+            StringAssert.Contains(
+                requirement,
+                "GPU",
+                $"LanguageModel-backed {modelType} also runs on GPU, so its requirement should mention GPU.");
+        }
+    }
+
+    [TestMethod]
+    public void GetHardwareRequirementInfoSpeechAndVsrMentionCpu()
+    {
+        foreach (var modelType in new[] { ModelType.SpeechRecognition, ModelType.VideoSuperRes })
+        {
+            var (requirement, _) = WcrApiHelpers.GetHardwareRequirementInfo(modelType);
+
+            StringAssert.Contains(
+                requirement,
+                "CPU",
+                $"{modelType} also runs on CPU, so its requirement should mention CPU.");
+        }
+    }
+
+    [TestMethod]
+    public void GetHardwareRequirementInfoNpuOnlyFallsBackToDefault()
+    {
+        // OCR has no SupportedHardwareAccelerators in apis.json, so it is NPU-only and should
+        // fall back to the generic Copilot+ PC requirement rather than mention GPU or CPU.
+        var (requirement, learnMoreUri) = WcrApiHelpers.GetHardwareRequirementInfo(ModelType.TextRecognitionOCR);
+
+        Assert.AreEqual("A Copilot+ PC is required.", requirement);
+        StringAssert.Contains(learnMoreUri, "supported-hardware");
+    }
+
+    [TestMethod]
+    public void GetHardwareRequirementInfoAllApisHaveValidLearnMoreUri()
+    {
+        foreach (var modelType in ModelTypeHelpers.ApiDefinitionDetails.Keys)
+        {
+            var (_, learnMoreUri) = WcrApiHelpers.GetHardwareRequirementInfo(modelType);
+
+            Assert.IsTrue(
+                Uri.TryCreate(learnMoreUri, UriKind.Absolute, out var uri) && uri.Scheme == Uri.UriSchemeHttps,
+                $"GetHardwareRequirementInfo should return a valid https URL for {modelType}, got '{learnMoreUri}'.");
+        }
+    }
 }

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -214,6 +214,9 @@ internal sealed partial class SampleContainer : UserControl
                 wcrModelUnavailable.Message = issue!;
             }
 
+            var notCompatibleApiType = ModelTypeHelpers.ApiDefinitionDetails.FirstOrDefault(md => md.Value.Id == notCompatibleModel.Id).Key;
+            wcrModelUnavailable.LearnMoreUri = new Uri(WcrApiHelpers.GetHardwareRequirementInfo(notCompatibleApiType).LearnMoreUri);
+
             VisualStateManager.GoToState(this, "WcrApiNotCompatible", true);
             SampleFrame.Content = null;
             return;

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -214,8 +214,11 @@ internal sealed partial class SampleContainer : UserControl
                 wcrModelUnavailable.Message = issue!;
             }
 
-            var notCompatibleApiType = ModelTypeHelpers.ApiDefinitionDetails.FirstOrDefault(md => md.Value.Id == notCompatibleModel.Id).Key;
-            wcrModelUnavailable.LearnMoreUri = new Uri(WcrApiHelpers.GetHardwareRequirementInfo(notCompatibleApiType).LearnMoreUri);
+            var apiEntry = ModelTypeHelpers.ApiDefinitionDetails.FirstOrDefault(md => md.Value.Id == notCompatibleModel.Id);
+            var learnMoreUri = apiEntry.Value is null
+                ? "https://learn.microsoft.com/windows/ai/apis/#supported-hardware"
+                : WcrApiHelpers.GetHardwareRequirementInfo(apiEntry.Key).LearnMoreUri;
+            wcrModelUnavailable.LearnMoreUri = new Uri(learnMoreUri);
 
             VisualStateManager.GoToState(this, "WcrApiNotCompatible", true);
             SampleFrame.Content = null;

--- a/AIDevGallery/Controls/WcrModelDownloader.xaml
+++ b/AIDevGallery/Controls/WcrModelDownloader.xaml
@@ -31,8 +31,16 @@
                 IsTextSelectionEnabled="True"
                 TextAlignment="Center"
                 TextWrapping="Wrap">
-                <Run x:Name="ModelDownloadInfoRun" Text="This Windows AI API requires a one-time model download via Windows Update." /><LineBreak /> <LineBreak />
-                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/ai/apis/model-setup#prerequisites" UnderlineStyle="None">A Copilot+ PC with Windows 11 Build 26120.3073 or higher is required</Hyperlink>
+                <Run x:Name="ModelDownloadInfoRun" Text="This Windows AI API requires a one-time model download via Windows Update." />
+            </TextBlock>
+            <TextBlock
+                x:Name="HardwareRequirementBlock"
+                FontSize="12"
+                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                IsTextSelectionEnabled="True"
+                TextAlignment="Center"
+                TextWrapping="Wrap">
+                <Hyperlink x:Name="HardwareRequirementLink" NavigateUri="https://learn.microsoft.com/windows/ai/apis/#supported-hardware" UnderlineStyle="None"><Run x:Name="HardwareRequirementText" Text="A Copilot+ PC is required." /></Hyperlink>
             </TextBlock>
             <TextBlock
                 x:Name="WindowsInsiderInfoText"
@@ -96,8 +104,8 @@
                 FontWeight="SemiBold"
                 Text="Model download error"
                 TextAlignment="Center" />
-            <TextBlock FontSize="12" TextAlignment="Center">
-                <Hyperlink NavigateUri="https://learn.microsoft.com/windows/ai/apis/model-setup#prerequisites" UnderlineStyle="None">A Copilot+ PC with Windows 11 Build 26120.3073 or higher is required</Hyperlink>
+            <TextBlock x:Name="ErrorHardwareRequirementBlock" FontSize="12" TextAlignment="Center">
+                <Hyperlink x:Name="ErrorHardwareRequirementLink" NavigateUri="https://learn.microsoft.com/windows/ai/apis/#supported-hardware" UnderlineStyle="None"><Run x:Name="ErrorHardwareRequirementText" Text="A Copilot+ PC is required." /></Hyperlink>
             </TextBlock>
             <TextBlock
                 x:Name="WindowsInsiderErrorText"

--- a/AIDevGallery/Controls/WcrModelDownloader.xaml
+++ b/AIDevGallery/Controls/WcrModelDownloader.xaml
@@ -31,15 +31,7 @@
                 IsTextSelectionEnabled="True"
                 TextAlignment="Center"
                 TextWrapping="Wrap">
-                <Run x:Name="ModelDownloadInfoRun" Text="This Windows AI API requires a one-time model download via Windows Update." />
-            </TextBlock>
-            <TextBlock
-                x:Name="HardwareRequirementBlock"
-                FontSize="12"
-                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                IsTextSelectionEnabled="True"
-                TextAlignment="Center"
-                TextWrapping="Wrap">
+                <Run x:Name="ModelDownloadInfoRun" Text="This Windows AI API requires a one-time model download via Windows Update." /><LineBreak /> <LineBreak />
                 <Hyperlink x:Name="HardwareRequirementLink" NavigateUri="https://learn.microsoft.com/windows/ai/apis/#supported-hardware" UnderlineStyle="None"><Run x:Name="HardwareRequirementText" Text="A Copilot+ PC is required." /></Hyperlink>
             </TextBlock>
             <TextBlock
@@ -104,7 +96,7 @@
                 FontWeight="SemiBold"
                 Text="Model download error"
                 TextAlignment="Center" />
-            <TextBlock x:Name="ErrorHardwareRequirementBlock" FontSize="12" TextAlignment="Center">
+            <TextBlock FontSize="12" TextAlignment="Center">
                 <Hyperlink x:Name="ErrorHardwareRequirementLink" NavigateUri="https://learn.microsoft.com/windows/ai/apis/#supported-hardware" UnderlineStyle="None"><Run x:Name="ErrorHardwareRequirementText" Text="A Copilot+ PC is required." /></Hyperlink>
             </TextBlock>
             <TextBlock

--- a/AIDevGallery/Controls/WcrModelDownloader.xaml.cs
+++ b/AIDevGallery/Controls/WcrModelDownloader.xaml.cs
@@ -162,13 +162,10 @@ internal sealed partial class WcrModelDownloader : UserControl
         this.sampleId = sampleId;
 
         var (hardwareRequirement, supportedHardwareUri) = WcrApiHelpers.GetHardwareRequirementInfo(modelType);
-        var hasHardwareRequirement = !string.IsNullOrEmpty(hardwareRequirement);
         HardwareRequirementText.Text = hardwareRequirement;
         HardwareRequirementLink.NavigateUri = new Uri(supportedHardwareUri);
-        HardwareRequirementBlock.Visibility = hasHardwareRequirement ? Visibility.Visible : Visibility.Collapsed;
         ErrorHardwareRequirementText.Text = hardwareRequirement;
         ErrorHardwareRequirementLink.NavigateUri = new Uri(supportedHardwareUri);
-        ErrorHardwareRequirementBlock.Visibility = hasHardwareRequirement ? Visibility.Visible : Visibility.Collapsed;
 
         // TODO: Remove after SDXL is released to retail
         WindowsInsiderInfoText.Visibility = WcrApiHelpers.IsImageGeneratorBacked(modelType)

--- a/AIDevGallery/Controls/WcrModelDownloader.xaml.cs
+++ b/AIDevGallery/Controls/WcrModelDownloader.xaml.cs
@@ -161,6 +161,15 @@ internal sealed partial class WcrModelDownloader : UserControl
         this.modelTypeHint = modelType;
         this.sampleId = sampleId;
 
+        var (hardwareRequirement, supportedHardwareUri) = WcrApiHelpers.GetHardwareRequirementInfo(modelType);
+        var hasHardwareRequirement = !string.IsNullOrEmpty(hardwareRequirement);
+        HardwareRequirementText.Text = hardwareRequirement;
+        HardwareRequirementLink.NavigateUri = new Uri(supportedHardwareUri);
+        HardwareRequirementBlock.Visibility = hasHardwareRequirement ? Visibility.Visible : Visibility.Collapsed;
+        ErrorHardwareRequirementText.Text = hardwareRequirement;
+        ErrorHardwareRequirementLink.NavigateUri = new Uri(supportedHardwareUri);
+        ErrorHardwareRequirementBlock.Visibility = hasHardwareRequirement ? Visibility.Visible : Visibility.Collapsed;
+
         // TODO: Remove after SDXL is released to retail
         WindowsInsiderInfoText.Visibility = WcrApiHelpers.IsImageGeneratorBacked(modelType)
             ? Visibility.Visible

--- a/AIDevGallery/Controls/WcrModelUnavailable.xaml.cs
+++ b/AIDevGallery/Controls/WcrModelUnavailable.xaml.cs
@@ -10,7 +10,7 @@ namespace AIDevGallery.Controls;
 internal sealed partial class WcrModelUnavailable : UserControl
 {
     public static readonly DependencyProperty TitleProperty = DependencyProperty.Register(
-        nameof(Title), typeof(string), typeof(WcrModelUnavailable), new PropertyMetadata("Copilot+ PC required"));
+        nameof(Title), typeof(string), typeof(WcrModelUnavailable), new PropertyMetadata("This device isn't supported"));
 
     public string Title
     {
@@ -19,7 +19,7 @@ internal sealed partial class WcrModelUnavailable : UserControl
     }
 
     public static readonly DependencyProperty MessageProperty = DependencyProperty.Register(
-        nameof(Message), typeof(string), typeof(WcrModelUnavailable), new PropertyMetadata("This Windows AI API requires a Copilot+ PC and Windows 11 Insider Preview Build 26120.3073."));
+        nameof(Message), typeof(string), typeof(WcrModelUnavailable), new PropertyMetadata("This Windows AI API isn't supported on this device."));
 
     public string Message
     {

--- a/AIDevGallery/Models/ModelCompatibility.cs
+++ b/AIDevGallery/Models/ModelCompatibility.cs
@@ -45,7 +45,7 @@ internal class ModelCompatibility
             else
             {
                 compatibility = ModelCompatibilityState.NotCompatible;
-                description = $"{WcrApiHelpers.GetHardwareRequirementInfo(apiType).Requirement}\n {WcrApiHelpers.GetStringDescription(apiType, availbility)}";
+                description = $"{WcrApiHelpers.GetHardwareRequirementInfo(apiType).Requirement}\n{WcrApiHelpers.GetStringDescription(apiType, availbility)}";
             }
         }
         else if (DeviceUtils.IsArm64() && modelDetails.SupportedOnQualcomm == false)

--- a/AIDevGallery/Models/ModelCompatibility.cs
+++ b/AIDevGallery/Models/ModelCompatibility.cs
@@ -45,11 +45,7 @@ internal class ModelCompatibility
             else
             {
                 compatibility = ModelCompatibilityState.NotCompatible;
-                var hardwareRequirement = WcrApiHelpers.GetHardwareRequirementInfo(apiType).Requirement;
-                var statusDescription = WcrApiHelpers.GetStringDescription(apiType, availbility);
-                description = string.IsNullOrEmpty(hardwareRequirement)
-                    ? statusDescription
-                    : $"{hardwareRequirement}\n {statusDescription}";
+                description = $"{WcrApiHelpers.GetHardwareRequirementInfo(apiType).Requirement}\n {WcrApiHelpers.GetStringDescription(apiType, availbility)}";
             }
         }
         else if (DeviceUtils.IsArm64() && modelDetails.SupportedOnQualcomm == false)

--- a/AIDevGallery/Models/ModelCompatibility.cs
+++ b/AIDevGallery/Models/ModelCompatibility.cs
@@ -45,7 +45,11 @@ internal class ModelCompatibility
             else
             {
                 compatibility = ModelCompatibilityState.NotCompatible;
-                description = $"This Windows AI API requires a Copilot+ PC and a Windows 11 Insider Preview Build 26120.3073.\n {WcrApiHelpers.GetStringDescription(apiType, availbility)}";
+                var hardwareRequirement = WcrApiHelpers.GetHardwareRequirementInfo(apiType).Requirement;
+                var statusDescription = WcrApiHelpers.GetStringDescription(apiType, availbility);
+                description = string.IsNullOrEmpty(hardwareRequirement)
+                    ? statusDescription
+                    : $"{hardwareRequirement}\n {statusDescription}";
             }
         }
         else if (DeviceUtils.IsArm64() && modelDetails.SupportedOnQualcomm == false)

--- a/AIDevGallery/Models/Samples.cs
+++ b/AIDevGallery/Models/Samples.cs
@@ -57,6 +57,8 @@ internal class ApiDefinition
     public string License { get; init; } = null!;
     public string SampleIdToShowInDocs { get; set; } = null!;
     public string? Category { get; init; }
+    public List<HardwareAccelerator>? SupportedHardwareAccelerators { get; init; }
+    public string? SupportedHardwareUrl { get; init; }
 }
 
 internal class ModelDetails

--- a/AIDevGallery/Samples/Definitions/WcrApis/WcrApiHelpers.cs
+++ b/AIDevGallery/Samples/Definitions/WcrApis/WcrApiHelpers.cs
@@ -18,6 +18,12 @@ namespace AIDevGallery.Samples;
 
 internal static class WcrApiHelpers
 {
+    // The requirement sentence is derived from each API's SupportedHardwareAccelerators - https://learn.microsoft.com/en-us/windows/ai/apis/#supported-hardware
+    private const string DefaultHardwareRequirement = "A Copilot+ PC is required.";
+    private const string CopilotPlusOrGpuRequirement = "A Copilot+ PC, or a Windows 11 PC with a supported GPU, is required.";
+    private const string CopilotPlusOrCpuRequirement = "A Copilot+ PC, or a Windows 11 PC with a supported CPU, is required.";
+    private const string DefaultSupportedHardwareUrl = "https://learn.microsoft.com/windows/ai/apis/#supported-hardware";
+
     private static readonly HashSet<ModelType> LanguageModelBacked = new()
     {
         ModelType.PhiSilica,
@@ -34,6 +40,7 @@ internal static class WcrApiHelpers
         ModelType.RestyleImage,
         ModelType.ColoringBook
     };
+
     private static readonly Dictionary<ModelType, Func<AIFeatureReadyState>> CompatibilityCheckers = new()
     {
         {
@@ -219,5 +226,30 @@ internal static class WcrApiHelpers
     public static bool IsImageGeneratorBacked(ModelType type)
     {
         return ImageGeneratorBacked.Contains(type);
+    }
+
+    // Returns the hardware requirement info - https://learn.microsoft.com/en-us/windows/ai/apis/#supported-hardware
+    public static (string Requirement, string LearnMoreUri) GetHardwareRequirementInfo(ModelType type)
+    {
+        if (!ModelTypeHelpers.ApiDefinitionDetails.TryGetValue(type, out var apiDefinition))
+        {
+            return (DefaultHardwareRequirement, DefaultSupportedHardwareUrl);
+        }
+
+        var learnMoreUri = string.IsNullOrEmpty(apiDefinition.SupportedHardwareUrl)
+            ? DefaultSupportedHardwareUrl
+            : apiDefinition.SupportedHardwareUrl!;
+
+        var runsOnGpu = apiDefinition.SupportedHardwareAccelerators?.Contains(HardwareAccelerator.GPU) == true;
+        var runsOnCpu = apiDefinition.SupportedHardwareAccelerators?.Contains(HardwareAccelerator.CPU) == true;
+        var requirement = (runsOnGpu, runsOnCpu) switch
+        {
+            (true, true) => string.Empty,
+            (true, false) => CopilotPlusOrGpuRequirement,
+            (false, true) => CopilotPlusOrCpuRequirement,
+            _ => DefaultHardwareRequirement,
+        };
+
+        return (requirement, learnMoreUri);
     }
 }

--- a/AIDevGallery/Samples/Definitions/WcrApis/WcrApiHelpers.cs
+++ b/AIDevGallery/Samples/Definitions/WcrApis/WcrApiHelpers.cs
@@ -22,6 +22,7 @@ internal static class WcrApiHelpers
     private const string DefaultHardwareRequirement = "A Copilot+ PC is required.";
     private const string CopilotPlusOrGpuRequirement = "A Copilot+ PC, or a Windows 11 PC with a supported GPU, is required.";
     private const string CopilotPlusOrCpuRequirement = "A Copilot+ PC, or a Windows 11 PC with a supported CPU, is required.";
+    private const string AnyCompatibleHardwareRequirement = "A Copilot+ PC, or a Windows 11 PC with a supported GPU or CPU, is required.";
     private const string DefaultSupportedHardwareUrl = "https://learn.microsoft.com/windows/ai/apis/#supported-hardware";
 
     private static readonly HashSet<ModelType> LanguageModelBacked = new()
@@ -244,7 +245,7 @@ internal static class WcrApiHelpers
         var runsOnCpu = apiDefinition.SupportedHardwareAccelerators?.Contains(HardwareAccelerator.CPU) == true;
         var requirement = (runsOnGpu, runsOnCpu) switch
         {
-            (true, true) => string.Empty,
+            (true, true) => AnyCompatibleHardwareRequirement,
             (true, false) => CopilotPlusOrGpuRequirement,
             (false, true) => CopilotPlusOrCpuRequirement,
             _ => DefaultHardwareRequirement,

--- a/AIDevGallery/Samples/Definitions/WcrApis/apis.json
+++ b/AIDevGallery/Samples/Definitions/WcrApis/apis.json
@@ -13,7 +13,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "21f2c4a5-3d8e-4b7a-9c0f-6d2e5f3b1c8d",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "PhiSilicaLora": {
         "Id": "6b319cbc-59e5-4ed0-af33-e7575bee7475",
@@ -24,7 +26,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica-lora.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "3e392b7f-02a8-45e0-bed1-f75186368f12",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "TextSummarizer": {
         "Id": "55eb4d48-3908-44ac-95b1-fa47318a5cbf",
@@ -35,7 +39,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "3b0582ef-3278-489a-8f71-3ee1379aed2b",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "TextRewriter": {
         "Id": "4084554c-a4ce-4624-a1e4-871a1d3df5d6",
@@ -46,7 +52,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "69e816fe-1893-4884-bea6-b3d247951a6b",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "DescribeYourChange": {
         "Id": "c5f8d3a7-9e2b-4f6a-8d1c-7b3e5a9c4f2d",
@@ -57,7 +65,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "a7d4e8f3-2b6c-4f9a-b1e5-3c7d9a8e5f2b",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "TextToTableConverter": {
         "Id": "b8a3dc48-a9e7-4697-b178-70c139887e9b",
@@ -68,7 +78,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/phi-silica.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "ff611809-aa53-47e1-a5d9-5210f01b2e3d",
-        "Category": "Phi Silica"
+        "Category": "Phi Silica",
+        "SupportedHardwareAccelerators": [ "NPU", "GPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/phi-silica#supported-hardware"
       },
       "TextRecognitionOCR": {
         "Id": "4bcc0137-0e9a-4eda-8096-b235fcb0e98b",
@@ -217,7 +229,9 @@
         "Description": "Improve video resolution.",
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/video-super-resolution.md",
         "License": "ms-pl",
-        "SampleIdToShowInDocs": "c3252e18-1d47-4689-adae-78fc66968650"
+        "SampleIdToShowInDocs": "c3252e18-1d47-4689-adae-78fc66968650",
+        "SupportedHardwareAccelerators": [ "NPU", "CPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/video-super-resolution#supported-hardware"
       },
       "SpeechRecognition": {
         "Id": "0d4f1c2a-7e3b-4c9e-9b8a-1f2d3c4b5a60",
@@ -228,7 +242,9 @@
         "ReadmeUrl": "https://github.com/MicrosoftDocs/windows-ai-docs/blob/docs/docs/apis/speech-recognition.md",
         "License": "ms-pl",
         "SampleIdToShowInDocs": "9c5b2e8a-1f7d-4d3c-9e6a-3b1c8e7f4d20",
-        "Category": "Speech"
+        "Category": "Speech",
+        "SupportedHardwareAccelerators": [ "NPU", "CPU" ],
+        "SupportedHardwareUrl": "https://learn.microsoft.com/windows/ai/apis/speech-recognition#supported-hardware"
       }
     }
   }


### PR DESCRIPTION
## Summary
The model-download/unavailable screens for Windows AI APIs showed a static "A Copilot+ PC with Windows 11 Build 26120.3073 or higher is required" message. That text dates from when all WCR APIs were NPU-only. Several APIs now also run off the NPU — Phi Silica & the language-model skills on GPU; Speech Recognition and Video Super Resolution on CPU — so a Copilot+ PC-only message is misleading.

## What changed
- Each Windows AI API now declares its hardware in **apis.json** via `SupportedHardwareAccelerators` (enum array, e.g. `["NPU","GPU"]`) and a `SupportedHardwareUrl`, surfaced through the source generator onto `ApiDefinition`.
- `WcrApiHelpers.GetHardwareRequirementInfo` derives the requirement sentence per API.
- "Learn more" links go to each API's supported-hardware doc; dropped the hardcoded build number.
- Updated download, error, and unavailable surfaces to show/hide the requirement dynamically.

## Tests
Added `WcrApiConfigurationTests` covering the derived GPU/CPU sentences, NPU-only fallback, and valid per-API URLs.