### PR TITLE
A11y: Fix overview group names, expandable nav item type, duplicate popup announcement, and Semantic ComboBox result count

### DIFF
--- a/AIDevGallery/Controls/SampleContainer.xaml
+++ b/AIDevGallery/Controls/SampleContainer.xaml
@@ -109,23 +109,14 @@
                         Visibility="Visible" />
                     <Button
                         x:Name="SampleDebugInfoButton"
+                        AutomationProperties.Name="Performance details"
                         Visibility="Collapsed"
                         Style="{StaticResource SubtleButtonStyle}">
                         <TextBlock
                             x:Name="SampleDebugInfoButtonText"
+                            AutomationProperties.AccessibilityView="Raw"
                             FontSize="12"
                             Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
-                        <Button.Flyout>
-                            <Flyout>
-                                <TextBlock
-                                    x:Name="SampleDebugInfoContent"
-                                    MaxWidth="300"
-                                    FontFamily="Consolas"
-                                    FontSize="14"
-                                    LineHeight="20"
-                                    TextWrapping="WrapWholeWords" />
-                            </Flyout>
-                        </Button.Flyout>
                     </Button>
                     <ContentPresenter x:Name="FooterContentPresenter" Content="{x:Bind FooterContent, Mode=OneWay}" />
                 </WrapPanel>

--- a/AIDevGallery/Controls/SampleContainer.xaml.cs
+++ b/AIDevGallery/Controls/SampleContainer.xaml.cs
@@ -342,12 +342,15 @@ internal sealed partial class SampleContainer : UserControl
             SampleDebugInfoButtonText.Visibility = Visibility.Collapsed;
             SampleDebugInfoButton.Visibility = Visibility.Collapsed;
             SampleDebugInfoButtonText.Text = string.Empty;
-            SampleDebugInfoContent.Text = string.Empty;
+            ToolTipService.SetToolTip(SampleDebugInfoButton, null);
+            Microsoft.UI.Xaml.Automation.AutomationProperties.SetFullDescription(SampleDebugInfoButton, string.Empty);
             return;
         }
 
         SampleDebugInfoButtonText.Text = contents.Split('\n')[0];
-        SampleDebugInfoContent.Text = contents;
+
+        ToolTipService.SetToolTip(SampleDebugInfoButton, contents);
+        Microsoft.UI.Xaml.Automation.AutomationProperties.SetFullDescription(SampleDebugInfoButton, contents);
 
         SampleDebugInfoButtonText.Visibility = Visibility.Visible;
         SampleDebugInfoButton.Visibility = Visibility.Visible;

--- a/AIDevGallery/Helpers/NavigationViewItemHelper.cs
+++ b/AIDevGallery/Helpers/NavigationViewItemHelper.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Automation;
 using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
@@ -13,19 +14,24 @@ internal static class NavigationViewItemHelper
 {
     public static void AppendControlTypeToName(this NavigationViewItem item, string label)
     {
-        item.Loaded += (sender, _) =>
+        RoutedEventHandler? loadedHandler = null;
+        loadedHandler = (sender, _) =>
         {
             if (sender is not NavigationViewItem navItem)
             {
                 return;
             }
 
-            var controlType = FrameworkElementAutomationPeer.CreatePeerForElement(navItem)?.GetLocalizedControlType();
+            var peer = FrameworkElementAutomationPeer.FromElement(navItem) ?? FrameworkElementAutomationPeer.CreatePeerForElement(navItem);
+            var controlType = peer?.GetLocalizedControlType();
             if (!string.IsNullOrWhiteSpace(controlType))
             {
                 AutomationProperties.SetName(navItem, $"{label}, {controlType}");
+                navItem.Loaded -= loadedHandler;
             }
         };
+
+        item.Loaded += loadedHandler;
     }
 
     public static IEnumerable<NavigationViewItem> Flatten(this IEnumerable<NavigationViewItem> source)

--- a/AIDevGallery/Helpers/NavigationViewItemHelper.cs
+++ b/AIDevGallery/Helpers/NavigationViewItemHelper.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.UI.Xaml.Automation;
+using Microsoft.UI.Xaml.Automation.Peers;
 using Microsoft.UI.Xaml.Controls;
 using System.Collections.Generic;
 using System.Linq;
@@ -9,6 +11,23 @@ namespace AIDevGallery.Helpers;
 
 internal static class NavigationViewItemHelper
 {
+    public static void AppendControlTypeToName(this NavigationViewItem item, string label)
+    {
+        item.Loaded += (sender, _) =>
+        {
+            if (sender is not NavigationViewItem navItem)
+            {
+                return;
+            }
+
+            var controlType = FrameworkElementAutomationPeer.CreatePeerForElement(navItem)?.GetLocalizedControlType();
+            if (!string.IsNullOrWhiteSpace(controlType))
+            {
+                AutomationProperties.SetName(navItem, $"{label}, {controlType}");
+            }
+        };
+    }
+
     public static IEnumerable<NavigationViewItem> Flatten(this IEnumerable<NavigationViewItem> source)
     {
         foreach (var item in source)

--- a/AIDevGallery/Pages/APIs/APIOverview.xaml
+++ b/AIDevGallery/Pages/APIs/APIOverview.xaml
@@ -108,11 +108,13 @@
                     <TextBlock
                         Margin="2,0,0,0"
                         FontSize="18"
+                        AutomationProperties.HeadingLevel="Level1"
                         Style="{StaticResource SubtitleTextBlockStyle}"
                         Text="Explore Windows AI APIs" />
 
                     <ItemsView
                         x:Name="APIViewer"
+                        AutomationProperties.Name="Explore Windows AI APIs"
                         IsItemInvokedEnabled="True"
                         ItemInvoked="APIViewer_ItemInvoked"
                         ItemsSource="{x:Bind wcrAPIs, Mode=OneWay}"

--- a/AIDevGallery/Pages/APIs/APISelectionPage.xaml.cs
+++ b/AIDevGallery/Pages/APIs/APISelectionPage.xaml.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using AIDevGallery.Helpers;
 using AIDevGallery.Models;
 using AIDevGallery.Samples;
 using AIDevGallery.Telemetry.Events;
@@ -79,6 +80,7 @@ internal sealed partial class APISelectionPage : Page
                         if (existingItem == null)
                         {
                             existingItem = new NavigationViewItem() { Content = CreateWrappedText(apiDefinition.Category), Icon = new FontIcon() { Glyph = "\uF0E2" }, SelectsOnInvoked = false, IsExpanded = true };
+                            existingItem.AppendControlTypeToName(apiDefinition.Category);
                             NavView.MenuItems.Add(existingItem);
                         }
 

--- a/AIDevGallery/Pages/Scenarios/ScenarioOverviewPage.xaml
+++ b/AIDevGallery/Pages/Scenarios/ScenarioOverviewPage.xaml
@@ -77,9 +77,11 @@
                                     <RowDefinition Height="*" />
                                 </Grid.RowDefinitions>
                                 <TextBlock
+                                    x:Name="CategoryHeader"
                                     Margin="2,0,0,0"
                                     FontSize="16"
                                     FontWeight="SemiBold"
+                                    AutomationProperties.HeadingLevel="Level1"
                                     Text="{x:Bind Name}"
                                     TextWrapping="Wrap" />
                                 <!--<TextBlock
@@ -89,6 +91,7 @@
                                 TextWrapping="Wrap" />-->
                                 <ItemsView
                                     Grid.Row="2"
+                                    AutomationProperties.Name="{x:Bind Name}"
                                     IsItemInvokedEnabled="True"
                                     ItemInvoked="ScenarioItemsView_ItemInvoked"
                                     ItemsSource="{x:Bind Scenarios}"

--- a/AIDevGallery/Pages/Scenarios/ScenarioSelectionPage.xaml.cs
+++ b/AIDevGallery/Pages/Scenarios/ScenarioSelectionPage.xaml.cs
@@ -111,6 +111,7 @@ internal sealed partial class ScenarioSelectionPage : Page
         foreach (var scenarioCategory in ScenarioCategoryHelpers.AllScenarioCategories)
         {
             var categoryMenu = new NavigationViewItem() { Content = scenarioCategory.Name, Icon = new FontIcon() { Glyph = scenarioCategory.Icon }, Tag = scenarioCategory };
+            categoryMenu.AppendControlTypeToName(scenarioCategory.Name);
             ToolTip categoryToolTip = new() { Content = scenarioCategory.Name };
             ToolTipService.SetToolTip(categoryMenu, categoryToolTip);
 

--- a/AIDevGallery/Samples/SharedCode/Controls/SemanticComboBox.cs
+++ b/AIDevGallery/Samples/SharedCode/Controls/SemanticComboBox.cs
@@ -88,11 +88,23 @@ internal sealed partial class SemanticComboBox : Control
     {
         // Since selecting an item will also change the text,
         // only listen to changes caused by user entering text.
-        if (args.Reason == AutoSuggestionBoxTextChangeReason.UserInput)
+        if (args.Reason != AutoSuggestionBoxTextChangeReason.UserInput)
         {
-            var searchResults = await Search(sender.Text);
-            sender.ItemsSource = searchResults.Select(item => item["Text"]);
+            return;
         }
+
+        string query = sender.Text;
+        var searchResults = await Search(query);
+
+        if (sender.Text != query)
+        {
+            return;
+        }
+
+        var suggestions = searchResults.Select(item => item["Text"]).ToList();
+        sender.ItemsSource = suggestions;
+
+        NarratorHelper.Announce(sender, $"{suggestions.Count} result{(suggestions.Count == 1 ? string.Empty : "s")}", "SemanticComboBoxSuggestionsActivityId"); // <exclude-line>
     }
 
     private static void OnEmbeddingGeneratorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)


### PR DESCRIPTION
Accessibility fixes for AI Dev Gallery. Each commit is a standalone fix and can be reviewed independently.

### Fixes
- **Announce category group names for overview page cards** — the grouped `ItemsView` on the Scenario/API overview pages now exposes an `AutomationProperties.Name`, and group titles use `HeadingLevel`, so Narrator announces each section.
- **Announce control type for expandable navigation items** — expandable category `NavigationViewItem`s (Scenarios / APIs) append their real control type to the accessible name so Narrator conveys they are expandable groups.
- **Avoid double popup announcement for performance details button** — the sample performance-details button no longer hosts a `Flyout`; its content is exposed via tooltip + `AutomationProperties.FullDescription`, so Narrator no longer announces "popup window" twice.
- **Announce Semantic ComboBox result count for screen readers** — the Semantic ComboBox announces the result count (e.g. "5 results") once per query via `NarratorHelper.Announce`, matching the app's main search box.
