### PR TITLE
fix: compile SelectorBar.xaml as a Page to prevent rare startup crash

### DIFF
--- a/AIDevGallery/AIDevGallery.csproj
+++ b/AIDevGallery/AIDevGallery.csproj
@@ -333,10 +333,7 @@
   <ItemGroup>
     <AdditionalFiles Include="**\NativeMethods.txt" />
   </ItemGroup>
-  <ItemGroup>
-    <Page Remove="Styles\SelectorBar.xaml" />
-  </ItemGroup>
-  
+
   <ItemGroup>
     <Content Include="Styles\SelectorBar.xaml" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
`SelectorBar.xaml` was excluded from XAML compilation (`<Page Remove>` in the csproj) and shipped as a loose **Content** file. Since App.xaml merges it as a resource dictionary (`<ResourceDictionary Source="/Styles/SelectorBar.xaml" />`), the framework had to resolve it at runtime via `ms-resource:///Files/Styles/SelectorBar.xaml`. In rare cases that runtime lookup can fail at startup, throwing during App.xaml parsing and crashing the app before any UI loads.

This has been present since the app's initial release. Every other `Styles/*.xaml` dictionary is a compiled/embedded Page - `SelectorBar` was the only one on this runtime-lookup path.

## Fix
Removed the `<Page Remove="Styles\SelectorBar.xaml" />` so the file compiles into an embedded XBF like every other style dictionary. App.xaml now binds to the embedded compiled resource instead of a runtime file lookup, eliminating the failure mode.

_Related to #61457801_

## Verification
- Build succeeds with 0 errors.
- Confirmed `Styles\SelectorBar.xbf` is now produced and embedded (listed in `embed.resfiles` alongside `Button`, `ComboBox`, `NavigationView`).
- App launches and the home page renders normally.