### PR TITLE
fix: Fix model picker icon theme switching and line-numbers Name length

### DIFF
--- a/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
+++ b/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml
@@ -87,7 +87,7 @@
                                 <ColumnDefinition Width="16" />
                                 <ColumnDefinition Width="*" />
                             </Grid.ColumnDefinitions>
-                            <Image Source="{x:Bind Icon}" />
+                            <Image Source="{x:Bind Icon, Mode=OneWay}" />
                             <TextBlock Grid.Column="1" Text="{x:Bind Name}" TextWrapping="Wrap" />
                         </Grid>
                     </DataTemplate>

--- a/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml.cs
+++ b/AIDevGallery/Controls/ModelPicker/ModelOrApiPicker.xaml.cs
@@ -30,6 +30,7 @@ internal sealed partial class ModelOrApiPicker : UserControl
     public ModelOrApiPicker()
     {
         this.InitializeComponent();
+        this.ActualThemeChanged += (_, _) => ModelPickerDefinition.RefreshThemeAwareIcons();
     }
 
     private void OnSelectedModelsChanged(object sender, List<ModelDetails?> args)
@@ -157,6 +158,7 @@ internal sealed partial class ModelOrApiPicker : UserControl
 
     private async Task LoadModels(List<ModelType> types)
     {
+        ModelPickerDefinition.RefreshThemeAwareIcons();
         modelTypeSelector.Items.Clear();
         modelsGrid.Children.Clear();
 

--- a/AIDevGallery/Controls/ModelPicker/ModelPickerViews/ModelPickerDefinitions.cs
+++ b/AIDevGallery/Controls/ModelPicker/ModelPickerViews/ModelPickerDefinitions.cs
@@ -3,13 +3,14 @@
 
 using AIDevGallery.ExternalModelUtils;
 using AIDevGallery.Utils;
+using CommunityToolkit.Mvvm.ComponentModel;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace AIDevGallery.Controls.ModelPickerViews;
 
-internal class ModelPickerDefinition
+internal class ModelPickerDefinition : ObservableObject
 {
     public static readonly Dictionary<string, ModelPickerDefinition> Definitions = new()
     {
@@ -71,9 +72,25 @@ internal class ModelPickerDefinition
         }
     };
 
+    private string icon = string.Empty;
+
     public required string Name { get; set; }
-    public required string Icon { get; set; }
+
+    public required string Icon
+    {
+        get => icon;
+        set => SetProperty(ref icon, value);
+    }
+
     public required string Id { get; set; }
     public required Func<BaseModelPickerView> CreatePicker { get; set; }
     public Func<Task<bool>> IsAvailable { get; set; } = () => Task.FromResult(true);
+
+    public static void RefreshThemeAwareIcons()
+    {
+        string suffix = AppUtils.GetThemeAssetSuffix();
+        Definitions["onnx"].Icon = $"ms-appx:///Assets/ModelIcons/CustomModel{suffix}.png";
+        Definitions["ollama"].Icon = $"ms-appx:///Assets/ModelIcons/Ollama{suffix}.png";
+        Definitions["openai"].Icon = $"ms-appx:///Assets/ModelIcons/OpenAI{suffix}.png";
+    }
 }

--- a/AIDevGallery/Controls/SampleContainer.xaml
+++ b/AIDevGallery/Controls/SampleContainer.xaml
@@ -164,6 +164,7 @@
                         </Grid.ColumnDefinitions>
                         <ScrollViewer
                             x:Name="LineNumbersScroller"
+                            AutomationProperties.Name="Line numbers"
                             HorizontalScrollBarVisibility="Hidden"
                             HorizontalScrollMode="Disabled"
                             VerticalScrollBarVisibility="Hidden"
@@ -172,7 +173,7 @@
                                 x:Name="LineNumbersTextBlock"
                                 Grid.Column="0"
                                 Margin="8,16"
-                                AutomationProperties.Name="Line numbers"
+                                AutomationProperties.AccessibilityView="Raw"
                                 FontFamily="Consolas"
                                 FontSize="14"
                                 Foreground="{ThemeResource AccentTextFillColorSecondaryBrush}"

--- a/AIDevGallery/MainWindow.xaml.cs
+++ b/AIDevGallery/MainWindow.xaml.cs
@@ -563,9 +563,7 @@ internal sealed partial class MainWindow : WindowEx
                         new Uri($"ms-appx:///Assets/ModelIcons/GitHub{AppUtils.GetThemeAssetSuffix()}.svg"));
             }
 
-            ModelPickerDefinition.Definitions["onnx"].Icon = $"ms-appx:///Assets/ModelIcons/CustomModel{AppUtils.GetThemeAssetSuffix()}.png";
-            ModelPickerDefinition.Definitions["ollama"].Icon = $"ms-appx:///Assets/ModelIcons/Ollama{AppUtils.GetThemeAssetSuffix()}.png";
-            ModelPickerDefinition.Definitions["openai"].Icon = $"ms-appx:///Assets/ModelIcons/OpenAI{AppUtils.GetThemeAssetSuffix()}.png";
+            ModelPickerDefinition.RefreshThemeAwareIcons();
             UpdateCaptionButtonColors();
         });
     }


### PR DESCRIPTION
**1. Model picker icons don't update on runtime theme switch**
The OpenAI / Custom models / Ollama icons were bound `OneTime` to paths computed once, so toggling the Windows theme at runtime left them stale (low-contrast in dark/light). Made `ModelPickerDefinition.Icon` observable + `OneWay`, and refresh the themed paths on `ActualThemeChanged` / picker open / `ColorValuesChanged`.

**2. Line-numbers pane UIA Name > 512 chars**
The line-numbers `ScrollViewer` had no explicit Name, so UIA concatenated every line number ("1 2 3 …"). Added `AutomationProperties.Name="Line numbers"` to the pane and excluded the decorative digits (`AccessibilityView="Raw"`).

Verified with Accessibility Insights and runtime theme toggling; builds clean.